### PR TITLE
Reflection Handling

### DIFF
--- a/pyhive/sqlalchemy_hive.py
+++ b/pyhive/sqlalchemy_hive.py
@@ -375,6 +375,7 @@ class HiveDialect(default.DefaultDialect):
     driver = b'thrift'
     preparer = HiveIdentifierPreparer
     statement_compiler = HiveCompiler
+    supports_views = True
     supports_alter = True
     supports_pk_autoincrement = False
     supports_default_values = False
@@ -408,6 +409,15 @@ class HiveDialect(default.DefaultDialect):
     def get_schema_names(self, connection, **kw):
         # Equivalent to SHOW DATABASES
         return [row.database_name for row in connection.execute('SHOW SCHEMAS')]
+
+    def get_view_names(self, connection, schema=None, **kw):
+
+        #HIVE does not provide functionality to query tableType
+        query = "SHOW TABLES"
+        if schema:
+            query += ' IN ' + self.identifier_preparer.quote_identifier(schema)
+        
+        return [row.tab_name for row in connection.execute(query)]
 
     def _get_table_columns(self, connection, table_name, schema):
         full_table = table_name


### PR DESCRIPTION
Previously, `metadata.reflect(view=True)` would result in a `NotImplementedError`.  Hive -- as far as I can tell -- does not provide *good* methods of querying [tableType](http://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.1.2/hive_javadocs/metastore/index.html?org/apache/hadoop/hive/metastore/TableType.html):  
- EXTERNAL_TABLE 
- INDEX_TABLE 
- MANAGED_TABLE 
- VIRTUAL_VIEW 

This PR punts to `SHOW TABLES`  but allows for [into](https://github.com/ContinuumIO/into/blob/6d84b70cf25a716db3f2d36dfa3bac1581e8612e/into/backends/sql.py#L95) to include `views=True` when inspecting databases and database like Engines: Hive/Impala

cc @mrocklin 