### PR TITLE
adding defaults into sql dialect

### DIFF
--- a/pyhive/sqlalchemy_hive.py
+++ b/pyhive/sqlalchemy_hive.py
@@ -398,9 +398,9 @@ class HiveDialect(default.DefaultDialect):
     def create_connect_args(self, url):
         kwargs = {
             'host': url.host,
-            'port': url.port,
+            'port': url.port or 10000,
             'username': url.username,
-            'database': url.database,
+            'database': url.database or 'default',
         }
         kwargs.update(url.query)
         return ([], kwargs)


### PR DESCRIPTION
PR pushes defaults for `database` and `port` into the dialect.  Many dialects like [postgresql](https://github.com/zzzeek/sqlalchemy/blob/1cb94d89d5c4db7a914d9f30ebe0b676ab4e175b/lib/sqlalchemy/dialects/postgresql/pypostgresql.py#L70-L75) have some amount of default behavior built into the dialect