### PR TITLE
PrestoDialect needs 'supports_native_boolean = True'

### DIFF
--- a/pyhive/sqlalchemy_presto.py
+++ b/pyhive/sqlalchemy_presto.py
@@ -58,6 +58,7 @@ class PrestoDialect(default.DefaultDialect):
     supports_unicode_binds = True
     returns_unicode_strings = True
     description_encoding = None
+    supports_native_boolean = True
 
     @classmethod
     def dbapi(cls):


### PR DESCRIPTION
PrestoDialect needs 'supports_native_boolean = True'.

Otherwise sqlalchemy would compile a where clause like "WHERE bool_column" into "WHERE bool_column = 1", this would fail with exception:
```
Operator EQUAL(boolean, bigint) not registered
```