### PR TITLE
Upgrade protocol version (requires Hive 0.13)

### DIFF
--- a/pyhive/presto.py
+++ b/pyhive/presto.py
@@ -225,7 +225,7 @@ class Cursor(common.DBAPICursor):
             assert self._columns
             new_data = response_json['data']
             self._decode_binary(new_data)
-            self._data += new_data
+            self._data += map(tuple, new_data)
         if 'nextUri' not in response_json:
             self._state = self._STATE_FINISHED
         if 'error' in response_json:

--- a/pyhive/tests/test_hive.py
+++ b/pyhive/tests/test_hive.py
@@ -52,7 +52,8 @@ class TestHive(unittest.TestCase, DBAPITestCase):
             ('union', 'UNION_TYPE', None, None, None, None, True),
             ('decimal', 'DECIMAL_TYPE', None, None, None, None, True),
         ])
-        self.assertEqual(cursor.fetchall(), [[
+        rows = cursor.fetchall()
+        expected = [(
             True,
             127,
             32767,
@@ -62,13 +63,16 @@ class TestHive(unittest.TestCase, DBAPITestCase):
             0.25,
             'a string',
             '1970-01-01 00:00:00.0',
-            '123',
+            b'123',
             '[1,2]',
             '{1:2,3:4}',
             '{"a":1,"b":2}',
             '{0:1}',
             '0.1',
-        ]])
+        )]
+        self.assertEqual(rows, expected)
+        # catch unicode/str
+        self.assertEqual(list(map(type, rows[0])), list(map(type, expected[0])))
 
     @with_cursor
     def test_async(self, cursor):
@@ -128,7 +132,7 @@ class TestHive(unittest.TestCase, DBAPITestCase):
             (orig,)
         )
         result = cursor.fetchall()
-        self.assertEqual(result, [[orig]])
+        self.assertEqual(result, [(orig,)])
 
     @with_cursor
     def test_no_result_set(self, cursor):

--- a/pyhive/tests/test_presto.py
+++ b/pyhive/tests/test_presto.py
@@ -56,7 +56,8 @@ class TestPresto(unittest.TestCase, DBAPITestCase):
             # ('union', 'varchar', None, None, None, None, True),
             # ('decimal', 'double', None, None, None, None, True),
         ])
-        self.assertEqual(cursor.fetchall(), [[
+        rows = cursor.fetchall()
+        expected = [(
             True,
             127,
             32767,
@@ -72,7 +73,10 @@ class TestPresto(unittest.TestCase, DBAPITestCase):
             [1, 2],  # struct is returned as a list of elements
             # '{0:1}',
             # 0.1,
-        ]])
+        )]
+        self.assertEqual(rows, expected)
+        # catch unicode/str
+        self.assertEqual(list(map(type, rows[0])), list(map(type, expected[0])))
 
     def test_noops(self):
         """The DB-API specification requires that certain actions exist, even though they might not
@@ -105,7 +109,7 @@ class TestPresto(unittest.TestCase, DBAPITestCase):
         def fail(*args, **kwargs):
             self.fail("Should not need requests.get after done polling")  # pragma: no cover
         with mock.patch('requests.get', fail):
-            self.assertEqual(cursor.fetchall(), [[1]])
+            self.assertEqual(cursor.fetchall(), [(1,)])
 
     @with_cursor
     def test_set_session(self, cursor):


### PR DESCRIPTION
This improves efficiency by about an order of magnitude and works around HIVE-10646.
Also standardize on returning tuples for consistency with SQLAlchemy.