### PR TITLE
Add Presto timestamp and date types

### DIFF
--- a/pyhive/sqlalchemy_presto.py
+++ b/pyhive/sqlalchemy_presto.py
@@ -38,6 +38,8 @@ _type_map = {
     'boolean': types.Boolean,
     'double': types.Float,
     'varchar': types.String,
+    'timestamp': types.TIMESTAMP,
+    'date': types.DATE,
 }
 
 


### PR DESCRIPTION
just using the plain sqlalchemy `TIMESTAMP` and `DATE`  types 