### PR TITLE
use fastbinary wrapper from thrift python library

### DIFF
--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -23,6 +23,11 @@ import thrift.protocol.TBinaryProtocol
 import thrift.transport.TSocket
 import thrift.transport.TTransport
 import thrift_sasl
+try:
+  from thrift.protocol import fastbinary
+except:
+  fastbinary = None
+
 
 # PEP 249 module globals
 apilevel = '2.0'
@@ -94,7 +99,12 @@ class Connection(object):
             raise NotImplementedError(
                 "Only NONE & NOSASL authentication are supported, got {}".format(auth))
 
-        protocol = thrift.protocol.TBinaryProtocol.TBinaryProtocol(self._transport)
+        if fastbinary:
+            # use c wrapper if available
+            protocol = thrift.protocol.TBinaryProtocol.TBinaryProtocolAccelerated(self._transport)
+        else:
+            protocol = thrift.protocol.TBinaryProtocol.TBinaryProtocol(self._transport)
+
         self._client = TCLIService.Client(protocol)
         # oldest version that still contains features we care about
         # "V6 uses binary type for binary payload (was string) and uses columnar result set"

--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -24,9 +24,9 @@ import thrift.transport.TSocket
 import thrift.transport.TTransport
 import thrift_sasl
 try:
-  from thrift.protocol import fastbinary
+    from thrift.protocol import fastbinary
 except:
-  fastbinary = None
+    fastbinary = None
 
 
 # PEP 249 module globals


### PR DESCRIPTION
Thrift library has wrapper `fastbinary` written on C, that works up to x2 faster than standart python wrapper according to my tests.