### PR TITLE
ParamEscaper Enhancement, added func `escape_sequence` in ParamEscaper

### DIFF
--- a/pyhive/common.py
+++ b/pyhive/common.py
@@ -223,7 +223,7 @@ class ParamEscaper(object):
             raise exc.ProgrammingError("Unsupported param format: {}".format(parameters))
 
     def escape_number(self, item):
-        return item
+        return str(item)
 
     def escape_string(self, item):
         # Need to decode UTF-8 because of old sqlalchemy.
@@ -238,11 +238,8 @@ class ParamEscaper(object):
         return "'{}'".format(item.replace("'", "''"))
 
     def escape_sequence(self, item):
-        l = []
-        for el in item:
-            v = self.escape_item(el)
-            l.append(v)
-        return "(" + ",".join(l) + ")"
+        l = map(self.escape_item, item)
+        return '(' + ','.join(l) + ')'
 
     def escape_item(self, item):
         if item is None:
@@ -251,7 +248,7 @@ class ParamEscaper(object):
             return self.escape_number(item)
         elif isinstance(item, basestring):
             return self.escape_string(item)
-        elif isinstance(item, (list, tuple, set, frozenset)):
+        elif isinstance(item, collections.Iterable):
             return self.escape_sequence(item)
         else:
             raise exc.ProgrammingError("Unsupported object {}".format(item))

--- a/pyhive/common.py
+++ b/pyhive/common.py
@@ -9,6 +9,7 @@ from builtins import bytes
 from builtins import int
 from builtins import object
 from builtins import range
+from builtins import str
 from past.builtins import basestring
 from pyhive import exc
 import abc
@@ -223,7 +224,7 @@ class ParamEscaper(object):
             raise exc.ProgrammingError("Unsupported param format: {}".format(parameters))
 
     def escape_number(self, item):
-        return str(item)
+        return item
 
     def escape_string(self, item):
         # Need to decode UTF-8 because of old sqlalchemy.
@@ -238,7 +239,7 @@ class ParamEscaper(object):
         return "'{}'".format(item.replace("'", "''"))
 
     def escape_sequence(self, item):
-        l = map(self.escape_item, item)
+        l = map(str, map(self.escape_item, item))
         return '(' + ','.join(l) + ')'
 
     def escape_item(self, item):

--- a/pyhive/common.py
+++ b/pyhive/common.py
@@ -237,6 +237,13 @@ class ParamEscaper(object):
         # (i.e. only special character is single quote)
         return "'{}'".format(item.replace("'", "''"))
 
+    def escape_sequence(self, item):
+        l = []
+        for el in item:
+            v = self.escape_item(el)
+            l.append(v)
+        return "(" + ",".join(l) + ")"
+
     def escape_item(self, item):
         if item is None:
             return 'NULL'
@@ -244,6 +251,8 @@ class ParamEscaper(object):
             return self.escape_number(item)
         elif isinstance(item, basestring):
             return self.escape_string(item)
+        elif isinstance(item, (list, tuple, set, frozenset)):
+            return self.escape_sequence(item)
         else:
             raise exc.ProgrammingError("Unsupported object {}".format(item))
 

--- a/pyhive/tests/dbapi_test_case.py
+++ b/pyhive/tests/dbapi_test_case.py
@@ -170,3 +170,11 @@ class DBAPITestCase(with_metaclass(abc.ABCMeta, object)):
         self.assertEqual(cursor.fetchall(), [(None,)] * 10000)
         cursor.execute('SELECT IF(a % 11 = 0, null, a) FROM many_rows')
         self.assertEqual(cursor.fetchall(), [(None if a % 11 == 0 else a,) for a in range(10000)])
+
+    @with_cursor
+    def test_sql_where_in(self, cursor):
+        cursor.execute('SELECT * FROM many_rows where a in %s', ([1, 2, 3],))
+        self.assertEqual(len(cursor.fetchall()), 3)
+        cursor.execute('SELECT * FROM many_rows where b in %s limit 10',
+                       (['blah'],))
+        self.assertEqual(len(cursor.fetchall()), 10)

--- a/pyhive/tests/test_common.py
+++ b/pyhive/tests/test_common.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from pyhive import common
+from past.builtins import unicode
 
 import unittest
 
@@ -15,9 +16,9 @@ class ParamEscaperTestCase(unittest.TestCase):
         self.assertEqual(self.escaper.escape_args({'foo': 'bar'}),
                          {'foo': "'bar'"})
         self.assertEqual(self.escaper.escape_args({'foo': 123}),
-                         {'foo': '123'})
+                         {'foo': 123})
         self.assertEqual(self.escaper.escape_args({'foo': 123.456}),
-                         {'foo': '123.456'})
+                         {'foo': 123.456})
         self.assertEqual(self.escaper.escape_args({'foo': ['a', 'b', 'c']}),
                          {'foo': "('a','b','c')"})
         self.assertEqual(self.escaper.escape_args({'foo': ('a', 'b', 'c')}),
@@ -30,8 +31,10 @@ class ParamEscaperTestCase(unittest.TestCase):
         self.assertEqual(self.escaper.escape_args(('bar',)),
                          ("'bar'",))
         self.assertEqual(self.escaper.escape_args([123]),
-                         ('123',))
+                         (123,))
         self.assertEqual(self.escaper.escape_args((123.456,)),
-                         ('123.456',))
+                         (123.456,))
         self.assertEqual(self.escaper.escape_args((['a', 'b', 'c'],)),
                          ("('a','b','c')",))
+        self.assertEqual(self.escaper.escape_args(([unicode(u'你好'), 'b', 'c'],)),
+                         ("('{}','b','c')".format(unicode(u'你好')),))

--- a/pyhive/tests/test_common.py
+++ b/pyhive/tests/test_common.py
@@ -1,0 +1,37 @@
+# encoding: utf-8
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from pyhive import common
+
+import unittest
+
+
+class ParamEscaperTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.escaper = common.ParamEscaper()
+
+    def test_escape_args(self):
+        self.assertEqual(self.escaper.escape_args({'foo': 'bar'}),
+                         {'foo': "'bar'"})
+        self.assertEqual(self.escaper.escape_args({'foo': 123}),
+                         {'foo': '123'})
+        self.assertEqual(self.escaper.escape_args({'foo': 123.456}),
+                         {'foo': '123.456'})
+        self.assertEqual(self.escaper.escape_args({'foo': ['a', 'b', 'c']}),
+                         {'foo': "('a','b','c')"})
+        self.assertEqual(self.escaper.escape_args({'foo': ('a', 'b', 'c')}),
+                         {'foo': "('a','b','c')"})
+        self.assertIn(self.escaper.escape_args({'foo': set(['a', 'b'])}),
+                      ({'foo': "('a','b')"}, {'foo': "('b','a')"}))
+        self.assertIn(self.escaper.escape_args({'foo': frozenset(['a', 'b'])}),
+                      ({'foo': "('a','b')"}, {'foo': "('b','a')"}))
+
+        self.assertEqual(self.escaper.escape_args(('bar',)),
+                         ("'bar'",))
+        self.assertEqual(self.escaper.escape_args([123]),
+                         ('123',))
+        self.assertEqual(self.escaper.escape_args((123.456,)),
+                         ('123.456',))
+        self.assertEqual(self.escaper.escape_args((['a', 'b', 'c'],)),
+                         ("('a','b','c')",))


### PR DESCRIPTION
added func `escape_sequence` in ParamEscaper, in order to support sequence
type (list, tuple, set, frozenset) in query params.

now we can do WHERE-IN query like:

```py
db_cursor.execute("SELECT * FROM table1 WHERE column IN %s", parameters=(['foo', 'bar'],))
```