### PR TITLE
Work around Hive/Spark SHOW SCHEMAS incompatibility

### DIFF
--- a/pyhive/sqlalchemy_hive.py
+++ b/pyhive/sqlalchemy_hive.py
@@ -201,7 +201,7 @@ class HiveDialect(default.DefaultDialect):
 
     def get_schema_names(self, connection, **kw):
         # Equivalent to SHOW DATABASES
-        return [row.database_name for row in connection.execute('SHOW SCHEMAS')]
+        return [row[0] for row in connection.execute('SHOW SCHEMAS')]
 
     def get_view_names(self, connection, schema=None, **kw):
         # Hive does not provide functionality to query tableType


### PR DESCRIPTION
Spark returns a different column name (databaseName instead of database_name), but for both spark and hive the first column contains the database name.