### PR TITLE
Add support for pushing dataframes to Presto databases.

### DIFF
--- a/pyhive/sqlalchemy_hive.py
+++ b/pyhive/sqlalchemy_hive.py
@@ -126,7 +126,7 @@ class HiveCompiler(SQLCompiler):
         return 'length{}'.format(self.function_argspec(fn, **kw))
 
 
-if StrictVersion(sqlalchemy.__version__) >= StrictVersion('0.6.0'):
+if StrictVersion(sqlalchemy.__version__) >= StrictVersion('0.7.0'):
     class HiveTypeCompiler(compiler.GenericTypeCompiler):
         def visit_INTEGER(self, type_):
             return 'INT'

--- a/pyhive/sqlalchemy_presto.py
+++ b/pyhive/sqlalchemy_presto.py
@@ -189,6 +189,7 @@ class PrestoDialect(default.DefaultDialect):
         # requests gives back Unicode strings
         return True
 
+
 if StrictVersion(sqlalchemy.__version__) < StrictVersion('0.7.0'):
     from pyhive import sqlalchemy_backports
 
@@ -196,3 +197,25 @@ if StrictVersion(sqlalchemy.__version__) < StrictVersion('0.7.0'):
         insp = sqlalchemy_backports.Inspector.from_engine(connection)
         return insp.reflecttable(table, include_columns, exclude_columns)
     PrestoDialect.reflecttable = reflecttable
+else:
+    class PrestoTypeCompiler(compiler.GenericTypeCompiler):
+
+        def visit_CLOB(self, type_, **kw):
+            raise ValueError("Presto does not support the CLOB column type.")
+
+        def visit_NCLOB(self, type_, **kw):
+            raise ValueError("Presto does not support the NCLOB column type.")
+
+        def visit_DATETIME(self, type_, **kw):
+            raise ValueError("Presto does not support the DATETIME column type.")
+
+        def visit_FLOAT(self, type_, **kw):
+            return "DOUBLE"
+
+        def visit_TEXT(self, type_, **kw):
+            if type_.length:
+                return 'VARCHAR({:d})'.format(type_.length)
+            else:
+                return 'VARCHAR'
+
+    PrestoDialect.type_compiler = PrestoTypeCompiler


### PR DESCRIPTION
Hi @jingw,

Another small patch to enable writing pandas dataframes to Presto databases. No tests as yet.

The Hive change was just to fix an inconsistent 0.6.0 vs 0.7.0 specification, that led to HiveTypeCompiler being defined, but never used.