### PR TITLE
Fix HiveDecimal bug for None and parse password to conn

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,11 @@ Passing session configuration
         'hive://user@host:10000/database',
         connect_args={'configuration': {'hive.exec.reducers.max': '123'}},
     )
-
+    # SQLAlchemy with LDAP
+    create_engine(
+        'hive://user:password@host:10000/database',
+        connect_args={'auth': 'LDAP'},
+    )
 Requirements
 ============
 

--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -86,7 +86,8 @@ class Connection(object):
         configuration = configuration or {}
 
         if (password is not None) != (auth == 'LDAP'):
-            raise ValueError("password should be set if and only if in LDAP mode")
+            raise ValueError("password should be set if and only if in LDAP mode\n"
+                             "Remove password or add auth='LDAP'")
         if (kerberos_service_name is not None) != (auth == 'KERBEROS'):
             raise ValueError("kerberos_service_name should be set if and only if in KERBEROS mode")
 

--- a/pyhive/sqlalchemy_hive.py
+++ b/pyhive/sqlalchemy_hive.py
@@ -60,7 +60,8 @@ class HiveDecimal(HiveStringTypeBase):
     impl = types.DECIMAL
 
     def process_result_value(self, value, dialect):
-        return decimal.Decimal(value)
+        if value is not None:
+            return decimal.Decimal(value)
 
 
 class HiveIdentifierPreparer(compiler.IdentifierPreparer):
@@ -194,6 +195,7 @@ class HiveDialect(default.DefaultDialect):
             'host': url.host,
             'port': url.port or 10000,
             'username': url.username,
+            'password': url.password,
             'database': url.database or 'default',
         }
         kwargs.update(url.query)


### PR DESCRIPTION
* CLA submitted

* If HiveDecimal value is None, return None
* enable parsing password from connection string and passing to Connection
* clarify how to pass `auth='LDAP'` for SQLAlchemy engine with password