### PR TITLE
Fix `get_table_names`  for SparkSQL

### DIFF
--- a/pyhive/sqlalchemy_hive.py
+++ b/pyhive/sqlalchemy_hive.py
@@ -300,7 +300,8 @@ class HiveDialect(default.DefaultDialect):
         query = 'SHOW TABLES'
         if schema:
             query += ' IN ' + self.identifier_preparer.quote_identifier(schema)
-        return [row[0] for row in connection.execute(query)]
+        # HS2 returns one column, but SparkSQL returns 2 (schema, table_name)
+        return [row[-1] for row in connection.execute(query)]
 
     def do_rollback(self, dbapi_connection):
         # No transactions for Hive


### PR DESCRIPTION
Even though SparkSQL is supposed to be compatible with HQL, `SHOW TABLES` returns two fields (schema, table) instead of one for Hive/HQL (table).

This code change should work in either case.
closes https://github.com/dropbox/PyHive/issues/150