### PR TITLE
Refine how requests_kwargs is disallowed.

### DIFF
--- a/pyhive/presto.py
+++ b/pyhive/presto.py
@@ -119,9 +119,9 @@ class Cursor(common.DBAPICursor):
 
         self._requests_session = requests_session or requests
 
-        if password is not None and requests_kwargs is not None:
-            raise ValueError("Cannot use both password and requests_kwargs")
         requests_kwargs = dict(requests_kwargs) if requests_kwargs is not None else {}
+        if password is not None and 'auth' in requests_kwargs:
+            raise ValueError("Cannot use both password and requests_kwargs authentication")
         for k in ('method', 'url', 'data', 'headers'):
             if k in requests_kwargs:
                 raise ValueError("Cannot override requests argument {}".format(k))

--- a/pyhive/tests/test_presto.py
+++ b/pyhive/tests/test_presto.py
@@ -182,11 +182,11 @@ class TestPresto(unittest.TestCase, DBAPITestCase):
         )
 
     def test_invalid_password_and_kwargs(self):
-        """password and requests_kwargs are incompatible"""
+        """password and requests_kwargs authentication is incompatible"""
         self.assertRaisesRegexp(
             ValueError, 'Cannot use both', lambda: presto.connect(
                 host=_HOST, username='user', password='secret', protocol='https',
-                requests_kwargs={}
+                requests_kwargs={'auth': requests.auth.HTTPBasicAuth('user', 'secret')}
             ).cursor()
         )
 


### PR DESCRIPTION
Right now, it is impossible to set a requests_kwargs along with a password. This limitation only make sense if you want to disallow an 'auth' field in requests_kwargs.
There are still other entries you want to have access to, such as 'verify', 'cert' or 'timeout' but still have to use the old username/password fields.

One of such example is superset by AirBnB. We wanted to enable LDAP database access to prestodb, but we could not do it cleanly. Due to the config being only JSON and our server using a self-signed certificate, we couldn't use `'auth': HTTPBasicAuth(username, password)` and we had to go with the old username and password entries. Add that the requirements defining the 'verify' value, it becomes unfriendly to setup.

Our current workaround is to define `REQUESTS_CA_BUNDLE` to our certificate when launching superset. Definitely not an elegant fix.

Here, this pull request aims to fix this by only restricting the usage of auth with a password field, not the entire requests_kwargs object. I have adapted the test to reflect this behavior.

I've filled the CLA form before doing this pull request.