### PR TITLE
Remove assertion when there is an error in Presto

### DIFF
--- a/pyhive/presto.py
+++ b/pyhive/presto.py
@@ -279,7 +279,6 @@ class Cursor(common.DBAPICursor):
         if 'nextUri' not in response_json:
             self._state = self._STATE_FINISHED
         if 'error' in response_json:
-            assert not self._nextUri, "Should not have nextUri if failed"
             raise DatabaseError(response_json['error'])
 
 


### PR DESCRIPTION
The new schema for response_json in Presto 0.166 contains nextUri and this assertion prevents useful error messages in response['error'] from being propagated when errors happen. Instead it sends "Should not have nextUri if failed" which is not a useful error message. 
@jingw 