### PR TITLE
Fix #144, don't show unrelated assertion

### DIFF
--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -296,7 +296,11 @@ class Cursor(common.DBAPICursor):
                                           sql, runAsync=async)
         _logger.debug(req)
         response = self._connection.client.ExecuteStatement(req)
-        _check_status(response)
+        try:
+            _check_status(response)
+        except OperationalError:
+            self._state = self._STATE_FINISHED
+            raise
         self._operationHandle = response.operationHandle
 
     def cancel(self):


### PR DESCRIPTION
Fixes #144 by correctly setting the state after an invalid hive execute.

Whenever a fetch is invoked, there are checks in `DBAPICursor.fetchone` to determine whether the current state is `_STATE_NONE` or `_STATE_FINISHED`.
https://github.com/dropbox/PyHive/blob/master/pyhive/common.py#L101
https://github.com/dropbox/PyHive/blob/master/pyhive/common.py#L105

On the presto side, an invalid execute results in `_STATE_FINISHED` and subsequent fetches return nothing.
https://github.com/dropbox/PyHive/blob/master/pyhive/presto.py#L280

To keep consistency, my proposed change on the hive side also sets the state to `_STATE_FINISHED` when an invalid execute is detected. @jingw if we prefer that a ProgrammingError be raised I can instead set the state to `_STATE_NONE` such that the ProgrammingError is triggered on subsequent fetches.

(Dropbox CLA signed)