### PR TITLE
Pass username to open session request

### DIFF
--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -163,6 +163,7 @@ class Connection(object):
             open_session_req = ttypes.TOpenSessionReq(
                 client_protocol=protocol_version,
                 configuration=configuration,
+                username=username,
             )
             response = self._client.OpenSession(open_session_req)
             _check_status(response)


### PR DESCRIPTION
This prevents authorization errors when using NOSASL.

Impyla does a similar thing here: https://github.com/cloudera/impyla/blob/master/impala/hiveserver2.py#L993