### PR TITLE
(More) idiomatic code for `fetchmany`, `fetchall`

### DIFF
--- a/pyhive/common.py
+++ b/pyhive/common.py
@@ -16,6 +16,7 @@ import abc
 import collections
 import time
 from future.utils import with_metaclass
+from itertools import islice
 
 
 class DBAPICursor(with_metaclass(abc.ABCMeta, object)):
@@ -124,14 +125,7 @@ class DBAPICursor(with_metaclass(abc.ABCMeta, object)):
         """
         if size is None:
             size = self.arraysize
-        result = []
-        for _ in range(size):
-            one = self.fetchone()
-            if one is None:
-                break
-            else:
-                result.append(one)
-        return result
+        return list(islice(iter(self.fetchone, None), size))
 
     def fetchall(self):
         """Fetch all (remaining) rows of a query result, returning them as a sequence of sequences
@@ -140,14 +134,7 @@ class DBAPICursor(with_metaclass(abc.ABCMeta, object)):
         An :py:class:`~pyhive.exc.Error` (or subclass) exception is raised if the previous call to
         :py:meth:`execute` did not produce any result set or no call was issued yet.
         """
-        result = []
-        while True:
-            one = self.fetchone()
-            if one is None:
-                break
-            else:
-                result.append(one)
-        return result
+        return list(iter(self.fetchone, None))
 
     @property
     def arraysize(self):

--- a/pyhive/common.py
+++ b/pyhive/common.py
@@ -8,7 +8,6 @@ from __future__ import unicode_literals
 from builtins import bytes
 from builtins import int
 from builtins import object
-from builtins import range
 from builtins import str
 from past.builtins import basestring
 from pyhive import exc


### PR DESCRIPTION
I went to look if `fetchall()` downloads the entire result in memory and found that it was coded in a low-level imperative C style, while Python has a perfectly good idiomatic approach for such things. So I simply couldn't resist and submitted a fix :-) Take it or leave it, I won't insist.

P.S. I'm editing this from GitHub UI, so haven't run any tests. And although I'm fairly sure it should work as is, consider it formally as a demonstration :-)