### PR TITLE
support numpy types by escaping type numbers.Real

### DIFF
--- a/pyhive/common.py
+++ b/pyhive/common.py
@@ -10,6 +10,7 @@ from builtins import int
 from builtins import object
 from builtins import range
 from builtins import str
+import numbers
 from past.builtins import basestring
 from pyhive import exc
 import abc
@@ -245,7 +246,7 @@ class ParamEscaper(object):
     def escape_item(self, item):
         if item is None:
             return 'NULL'
-        elif isinstance(item, (int, float)):
+        elif isinstance(item, numbers.Real):
             return self.escape_number(item)
         elif isinstance(item, basestring):
             return self.escape_string(item)


### PR DESCRIPTION
numpy int64 and float64 inconsistently derive from base `int` and `float` depending on python version. Checking against `numbers.Real` ensures correct behavior.

on python 3.6
```
>>> import numpy as np
>>> import numbers
>>> 
>>> isinstance(np.int64(1), int)
False
>>> isinstance(np.float64(1.), float)
True
>>> isinstance(np.int64(1), numbers.Real)
True
>>> isinstance(np.float64(1), numbers.Real)
True
```

on python 2.7
```
>>> import numpy as np
>>> import numbers
>>> 
>>> isinstance(np.int64(1), int)
True
>>> isinstance(np.int32(1), int)
False
>>> isinstance(np.float64(1.), float)
True
>>> isinstance(np.float32(1.), float)
False
>>> isinstance(np.int64(1), numbers.Real)
True
>>> isinstance(np.int32(1), numbers.Real)
True
>>> isinstance(np.float64(1), numbers.Real)
True
>>> isinstance(np.float32(1), numbers.Real)
True
```