### PR TITLE
Removing unreleased thrift_sasl comment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,9 +97,6 @@ PyHive works with
 - Python 2.7 / Python 3
 - For Presto: Presto install
 - For Hive: `HiveServer2 <https://cwiki.apache.org/confluence/display/Hive/Setting+up+HiveServer2>`_ daemon
-- For Python 3 + Hive + SASL, you currently need to install an unreleased version of ``thrift_sasl``
-  (``pip install git+https://github.com/cloudera/thrift_sasl``).
-  At the time of writing, the latest version of ``thrift_sasl`` was 0.2.1.
 
 Changelog
 =========


### PR DESCRIPTION
Hello. I might be removing this prematurely, but `pip search thrift_sasl` now shows 0.3.0. Can this comment be removed?

Also, I filled out the Dropbox Contributor License. Thanks in advance to everyone who maintains this.