### PR TITLE
Add type conversion for DECIMAL/TIMESTAMP

### DIFF
--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -7,6 +7,11 @@ Many docstrings in this file are based on the PEP, which is in the public domain
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import datetime
+import re
+from decimal import Decimal
+
 from TCLIService import TCLIService
 from TCLIService import constants
 from TCLIService import ttypes
@@ -30,6 +35,31 @@ threadsafety = 2  # Threads may share the module and connections.
 paramstyle = 'pyformat'  # Python extended format codes, e.g. ...WHERE name=%(name)s
 
 _logger = logging.getLogger(__name__)
+
+_TIMESTAMP_PATTERN = re.compile(r'(\d+-\d+-\d+ \d+:\d+:\d+(\.\d{,6})?)')
+
+
+def _parse_timestamp(value):
+    if value:
+        match = _TIMESTAMP_PATTERN.match(value)
+        if match:
+            if match.group(2):
+                format = '%Y-%m-%d %H:%M:%S.%f'
+                # use the pattern to truncate the value
+                value = match.group()
+            else:
+                format = '%Y-%m-%d %H:%M:%S'
+            value = datetime.datetime.strptime(value, format)
+        else:
+            raise Exception(
+                'Cannot convert "{}" into a datetime'.format(value))
+    else:
+        value = None
+    return value
+
+
+TYPES_CONVERTER = {"DECIMAL_TYPE": Decimal,
+                   "TIMESTAMP_TYPE": _parse_timestamp}
 
 
 class HiveParamEscaper(common.ParamEscaper):
@@ -320,8 +350,10 @@ class Cursor(common.DBAPICursor):
         )
         response = self._connection.client.FetchResults(req)
         _check_status(response)
+        schema = self.description
         assert not response.results.rows, 'expected data in columnar format'
-        columns = map(_unwrap_column, response.results.columns)
+        columns = [_unwrap_column(col, col_schema[1]) for col, col_schema in
+                   zip(response.results.columns, schema)]
         new_data = list(zip(*columns))
         self._data += new_data
         # response.hasMoreRows seems to always be False, so we instead check the number of rows
@@ -402,7 +434,7 @@ for type_id in constants.PRIMITIVE_TYPES:
 #
 
 
-def _unwrap_column(col):
+def _unwrap_column(col, type_=None):
     """Return a list of raw values from a TColumn instance."""
     for attr, wrapper in iteritems(col.__dict__):
         if wrapper is not None:
@@ -414,6 +446,9 @@ def _unwrap_column(col):
                 for b in range(8):
                     if byte & (1 << b):
                         result[i * 8 + b] = None
+            converter = TYPES_CONVERTER.get(type_, None)
+            if converter and type_:
+                result = [converter(row) if row else row for row in result]
             return result
     raise DataError("Got empty column value {}".format(col))  # pragma: no cover
 

--- a/pyhive/tests/test_hive.py
+++ b/pyhive/tests/test_hive.py
@@ -8,11 +8,13 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import contextlib
+import datetime
 import os
 import socket
 import subprocess
 import time
 import unittest
+from decimal import Decimal
 
 import mock
 import sasl
@@ -72,13 +74,13 @@ class TestHive(unittest.TestCase, DBAPITestCase):
             0.5,
             0.25,
             'a string',
-            '1970-01-01 00:00:00.0',
+            datetime.datetime(1970, 1, 1, 0, 0),
             b'123',
             '[1,2]',
             '{1:2,3:4}',
             '{"a":1,"b":2}',
             '{0:1}',
-            '0.1',
+            Decimal('0.1'),
         )]
         self.assertEqual(rows, expected)
         # catch unicode/str


### PR DESCRIPTION
In Impyla some types are converted (decimal and timestamp).

This is handy otherwise some elements (especially Decimal) are imported as strings.