### PR TITLE
Add __enter__ and __exit__ methods to pyhive

### DIFF
--- a/pyhive/presto.py
+++ b/pyhive/presto.py
@@ -53,6 +53,12 @@ class Connection(object):
         self._args = args
         self._kwargs = kwargs
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return self.close()
+
     def close(self):
         """Presto does not have anything to close"""
         # TODO cancel outstanding queries?


### PR DESCRIPTION
This allows to use `with` statements with the connection object. It follows what is done in https://github.com/prestodb/presto-python-client/blob/master/prestodb/dbapi.py#L121 and partially in #210 .