### PR TITLE
[WiP] Add support for DECIMAL type in Presto dialect's get_columns

### DIFF
--- a/pyhive/sqlalchemy_presto.py
+++ b/pyhive/sqlalchemy_presto.py
@@ -141,24 +141,28 @@ class PrestoDialect(default.DefaultDialect):
         except exc.NoSuchTableError:
             return False
 
+    def _get_column_type(self, column):
+        """Get column type based on a column row"""
+        coltype = _type_map.get(column.Type)
+        if column.Type.startswith('decimal'):
+            if all([c in column.Type for c in '(,)']):
+                details = column.Type.split('(')[1].strip(')')
+                precision, scale = details.split(',')
+                return types.DECIMAL(precision, scale)
+            else:
+                return types.DECIMAL
+        if not coltype:
+            util.warn("Did not recognize type '%s' of column '%s'" % (column.Type, column.Column))
+            return types.NullType
+        return coltype
+
     def get_columns(self, connection, table_name, schema=None, **kw):
         rows = self._get_table_columns(connection, table_name, schema)
         result = []
         for row in rows:
-            coltype = _type_map.get(row.Type)
-            if row.Type.startswith('decimal'):
-                if all([c in row.Type for c in '(,)']):
-                    details = row.Type.split('(')[1].strip(')')
-                    precision, scale = details.split(',')
-                    coltype = types.DECIMAL(precision, scale)
-                else:
-                    coltype = types.DECIMAL
-            if not coltype:
-                util.warn("Did not recognize type '%s' of column '%s'" % (row.Type, row.Column))
-                coltype = types.NullType
             result.append({
                 'name': row.Column,
-                'type': coltype,
+                'type': self._get_column_type(column=row),
                 # newer Presto no longer includes this column
                 'nullable': getattr(row, 'Null', True),
                 'default': None,

--- a/pyhive/tests/test_sqlalchemy_presto.py
+++ b/pyhive/tests/test_sqlalchemy_presto.py
@@ -65,7 +65,7 @@ class TestSqlAlchemyPresto(unittest.TestCase, SqlAlchemyTestCase):
         self.assertIsInstance(one_row_complex.c.array.type, types.NullType)
         self.assertIsInstance(one_row_complex.c.map.type, types.NullType)
         self.assertIsInstance(one_row_complex.c.struct.type, types.NullType)
-        self.assertIsInstance(one_row_complex.c.decimal.type, types.NullType)
+        self.assertIsInstance(one_row_complex.c.decimal.type, types.DECIMAL)
 
     def test_url_default(self):
         engine = create_engine('presto://localhost:8080/hive')


### PR DESCRIPTION
Currently, when running `inspector.get_columns` against a table using
the presto dialect, PyHive returns a `NullType`, which is wrong.

This patch adds support for sqla.types.DECIMAL and handles precision and
scale as expected.