### PR TITLE
Make PyHive work with Python 3.7 async

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,13 @@ DB-API (asynchronous)
 
     print cursor.fetchall()
 
+In Python 3.7 `async` became a keyword; you can use `async_` instead:
+
+.. code-block:: python
+
+    cursor.execute('SELECT * FROM my_awesome_data LIMIT 10', async_=True)
+
+
 SQLAlchemy
 ----------
 First install this package to register it with SQLAlchemy (see ``setup.py``).

--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -334,11 +334,19 @@ class Cursor(common.DBAPICursor):
         """Close the operation handle"""
         self._reset_state()
 
-    def execute(self, operation, parameters=None, async=False):
+    def execute(self, operation, parameters=None, **kwargs):
         """Prepare and execute a database operation (query or command).
 
         Return values are not defined.
         """
+        # backward compatibility with Python < 3.7
+        for kw in ['async', 'async_']:
+            if kw in kwargs:
+                async_ = kwargs[kw]
+                break
+        else:
+            async_ = False
+
         # Prepare statement
         if parameters is None:
             sql = operation
@@ -351,7 +359,7 @@ class Cursor(common.DBAPICursor):
         _logger.info('%s', sql)
 
         req = ttypes.TExecuteStatementReq(self._connection.sessionHandle,
-                                          sql, runAsync=async)
+                                          sql, runAsync=async_)
         _logger.debug(req)
         response = self._connection.client.ExecuteStatement(req)
         _check_status(response)

--- a/pyhive/tests/test_hive.py
+++ b/pyhive/tests/test_hive.py
@@ -88,7 +88,7 @@ class TestHive(unittest.TestCase, DBAPITestCase):
 
     @with_cursor
     def test_async(self, cursor):
-        cursor.execute('SELECT * FROM one_row', async=True)
+        cursor.execute('SELECT * FROM one_row', async_=True)
         unfinished_states = (
             ttypes.TOperationState.INITIALIZED_STATE,
             ttypes.TOperationState.RUNNING_STATE,
@@ -106,7 +106,7 @@ class TestHive(unittest.TestCase, DBAPITestCase):
         cursor.execute(
             "SELECT reflect('java.lang.Thread', 'sleep', 1000L * 1000L * 1000L) "
             "FROM one_row a JOIN one_row b",
-            async=True
+            async_=True
         )
         self.assertEqual(cursor.poll().operationState, ttypes.TOperationState.RUNNING_STATE)
         assert any('Stage' in line for line in cursor.fetch_logs())

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,5 +25,4 @@ filterwarnings =
     # TODO
     default:Did not recognize type:sqlalchemy.exc.SAWarning
     default:The Binary type has been renamed to LargeBinary:sqlalchemy.exc.SADeprecationWarning
-    default:'async' and 'await' will become reserved keywords:DeprecationWarning
     default:Please use assertRaisesRegex instead:DeprecationWarning


### PR DESCRIPTION
In Python 3.7 `async` became a keyword, breaking PyHive's `execute` method. This PR fixes it by allowing either `async` or `async_` to be passed as a keyword argument, in order to preserve backwards compatibility.

This fixes https://github.com/dropbox/PyHive/issues/148.