### PR TITLE
setup.py: Add PyPI trove classifiers for Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,11 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Database :: Front-Ends",
     ],
     install_requires=[


### PR DESCRIPTION
This PR will change https://pypi.org/project/PyHive to show which versions of Python are supported.  Other tools like https://github.com/brettcannon/caniusepython3 also rely on these [trove classifiers](https://pypi.org/pypi?%3Aaction=list_classifiers) to give projects confidence that their dependencies are not blocking them from upgrading to Python 3.