### PR TITLE
Add mapping for varchar to string for hive

### DIFF
--- a/pyhive/sqlalchemy_hive.py
+++ b/pyhive/sqlalchemy_hive.py
@@ -129,6 +129,7 @@ _type_map = {
     'double': types.Float,
     'string': types.String,
     'varchar': types.String,
+    'char': types.String,
     'date': HiveDate,
     'timestamp': HiveTimestamp,
     'binary': types.String,

--- a/pyhive/sqlalchemy_hive.py
+++ b/pyhive/sqlalchemy_hive.py
@@ -128,6 +128,7 @@ _type_map = {
     'float': types.Float,
     'double': types.Float,
     'string': types.String,
+    'varchar': types.String,
     'date': HiveDate,
     'timestamp': HiveTimestamp,
     'binary': types.String,


### PR DESCRIPTION
Noticed that pyhive doesn't have mapping for hive type `varchar`:

```
./venv/lib/python2.7/site-packages/pyhive/sqlalchemy_hive.py:277: SAWarning: Did not recognize type 'varchar' of column 'test_column'
  util.warn("Did not recognize type '%s' of column '%s'" % (col_type, col_name))
```