### PR TITLE
adding requests dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     install_requires=[
         'future',
         'python-dateutil',
+        'requests'
     ],
     extras_require={
         'presto': ['requests>=1.0.0'],


### PR DESCRIPTION
the presto client clearly depends on requests but this dependency is not explicitly declared so the library fails unless the dependency is resolved manually.