### PR TITLE
Make requests-kerberos truly optional

### DIFF
--- a/pyhive/presto.py
+++ b/pyhive/presto.py
@@ -18,7 +18,6 @@ import getpass
 import logging
 import requests
 from requests.auth import HTTPBasicAuth
-from requests_kerberos import HTTPKerberosAuth, OPTIONAL
 import os
 
 try:  # Python 3
@@ -139,6 +138,8 @@ class Cursor(common.DBAPICursor):
         requests_kwargs = dict(requests_kwargs) if requests_kwargs is not None else {}
 
         if KerberosRemoteServiceName is not None:
+            from requests_kerberos import HTTPKerberosAuth, OPTIONAL
+
             hostname_override = None
             if KerberosUseCanonicalHostname is not None \
                     and KerberosUseCanonicalHostname.lower() == 'false':


### PR DESCRIPTION
`requests-kerberos` is currently imported at the top level of `presto.py`, making it an actual required dependency of presto.
We can move the import inside the only branch it is used, so that we do not need to install it if we do not use it.