### PR TITLE
Minor refinement on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,8 +100,8 @@ Requirements
 
 Install using
 
-- ``pip install pyhive[hive]`` for the Hive interface and
-- ``pip install pyhive[presto]`` for the Presto interface.
+- ``pip install 'pyhive[hive]'`` for the Hive interface and
+- ``pip install 'pyhive[presto]'`` for the Presto interface.
 
 PyHive works with
 


### PR DESCRIPTION
Change  ``pip install pyhive[hive]`` into ``pip install 'pyhive[hive]'``.

This can help avoid errors like "zsh: no matches found: pyhive[hive]"