### PR TITLE
Fix CI errors reported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ matrix:
     # https://docs.python.org/devguide/#status-of-python-branches
     # One build pulls latest versions dynamically
     - python: 3.6
-      env: CDH=cdh5 CDH_VERSION=5 PRESTO=RELEASE SQLALCHEMY=sqlalchemy==1.2.8
+      env: CDH=cdh5 CDH_VERSION=5 PRESTO=RELEASE SQLALCHEMY=sqlalchemy>=1.3.0
     - python: 3.6
-      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147 SQLALCHEMY=sqlalchemy==1.2.8
+      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147 SQLALCHEMY=sqlalchemy>=1.3.0
     - python: 3.5
-      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147 SQLALCHEMY=sqlalchemy==1.2.8
+      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147 SQLALCHEMY=sqlalchemy>=1.3.0
     - python: 3.4
-      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147 SQLALCHEMY=sqlalchemy==1.2.8
+      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147 SQLALCHEMY=sqlalchemy>=1.3.0
     - python: 2.7
-      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147 SQLALCHEMY=sqlalchemy==1.2.8
+      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147 SQLALCHEMY=sqlalchemy>=1.3.0
 install:
   - ./scripts/travis-install.sh
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     # https://docs.python.org/devguide/#status-of-python-branches
     # One build pulls latest versions dynamically
     - python: 3.6
-      env: CDH=cdh5 CDH_VERSION=5 PRESTO=RELEASE SQLALCHEMY=sqlalchemy
+      env: CDH=cdh5 CDH_VERSION=5 PRESTO=RELEASE SQLALCHEMY=sqlalchemy==1.2.8
     - python: 3.6
       env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147 SQLALCHEMY=sqlalchemy==1.2.8
     - python: 3.5

--- a/pyhive/tests/sqlalchemy_test_case.py
+++ b/pyhive/tests/sqlalchemy_test_case.py
@@ -64,7 +64,8 @@ class SqlAlchemyTestCase(with_metaclass(abc.ABCMeta, object)):
         """When passed include_columns, reflecttable should filter out other columns"""
         one_row_complex = Table('one_row_complex', MetaData(bind=engine))
         engine.dialect.reflecttable(
-            connection, one_row_complex, include_columns=['int'], exclude_columns=[])
+            connection, one_row_complex, include_columns=['int'],
+            exclude_columns=[], resolve_fks=True)
         self.assertEqual(len(one_row_complex.c), 1)
         self.assertIsNotNone(one_row_complex.c.int)
         self.assertRaises(AttributeError, lambda: one_row_complex.c.tinyint)
@@ -86,14 +87,16 @@ class SqlAlchemyTestCase(with_metaclass(abc.ABCMeta, object)):
 
         many_rows = Table('many_rows', MetaData(bind=engine))
         engine.dialect.reflecttable(
-            connection, many_rows, include_columns=['a'], exclude_columns=[])
+            connection, many_rows, include_columns=['a'],
+            exclude_columns=[], resolve_fks=True)
         self.assertEqual(len(many_rows.c), 1)
         self.assertFalse(many_rows.c.a.index)
         self.assertFalse(many_rows.indexes)
 
         many_rows = Table('many_rows', MetaData(bind=engine))
         engine.dialect.reflecttable(
-            connection, many_rows, include_columns=['b'], exclude_columns=[])
+            connection, many_rows, include_columns=['b'],
+            exclude_columns=[], resolve_fks=True)
         self.assertEqual(len(many_rows.c), 1)
         self.assertEqual(repr(many_rows.indexes), repr({Index('partition', many_rows.c.b)}))
 

--- a/pyhive/tests/test_presto.py
+++ b/pyhive/tests/test_presto.py
@@ -96,7 +96,8 @@ class TestPresto(unittest.TestCase, DBAPITestCase):
             "FROM many_rows a "
             "CROSS JOIN many_rows b "
         )
-        self.assertIn(cursor.poll()['stats']['state'], ('STARTING', 'PLANNING', 'RUNNING'))
+        self.assertIn(cursor.poll()['stats']['state'], (
+            'STARTING', 'PLANNING', 'RUNNING', 'WAITING_FOR_RESOURCES', 'QUEUED'))
         cursor.cancel()
         self.assertIsNone(cursor.poll())
 
@@ -202,7 +203,7 @@ class TestPresto(unittest.TestCase, DBAPITestCase):
     def test_requests_kwargs(self):
         connection = presto.connect(
             host=_HOST, port=_PORT, source=self.id(),
-            requests_kwargs={'proxies': {'http': 'localhost:99999'}},
+            requests_kwargs={'proxies': {'http': 'localhost:9999'}},
         )
         cursor = connection.cursor()
         self.assertRaises(requests.exceptions.ProxyError,

--- a/pyhive/tests/test_sqlalchemy_hive.py
+++ b/pyhive/tests/test_sqlalchemy_hive.py
@@ -151,7 +151,7 @@ class TestSqlAlchemyHive(unittest.TestCase, SqlAlchemyTestCase):
             'NUMERIC', 'DECIMAL', 'TIMESTAMP', 'DATETIME', 'CLOB', 'BLOB',
             'BOOLEAN', 'SMALLINT', 'DATE', 'TIME',
             'String', 'Integer', 'SmallInteger',
-            'Numeric', 'Float', 'DateTime', 'Date', 'Time', 'Binary',
+            'Numeric', 'Float', 'DateTime', 'Date', 'Time', 'LargeBinary',
             'Boolean', 'Unicode', 'UnicodeText',
         ]
         cols = []

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     extras_require={
         'presto': ['requests>=1.0.0'],
         'hive': ['sasl>=0.2.1', 'thrift>=0.10.0', 'thrift_sasl>=0.1.0'],
-        'sqlalchemy': ['sqlalchemy>=0.8.7,<=1.2.8'],
+        'sqlalchemy': ['sqlalchemy>=1.3.0'],
         'kerberos': ['requests_kerberos>=0.12.0'],
     },
     tests_require=[
@@ -55,7 +55,7 @@ setup(
         'requests>=1.0.0',
         'requests_kerberos>=0.12.0',
         'sasl>=0.2.1',
-        'sqlalchemy>=0.12.0,<=1.2.8',
+        'sqlalchemy>=1.3.0',
         'thrift>=0.10.0',
     ],
     cmdclass={'test': PyTest},

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     extras_require={
         'presto': ['requests>=1.0.0'],
         'hive': ['sasl>=0.2.1', 'thrift>=0.10.0', 'thrift_sasl>=0.1.0'],
-        'sqlalchemy': ['sqlalchemy>=0.8.7'],
+        'sqlalchemy': ['sqlalchemy>=0.8.7,<=1.2.8'],
         'kerberos': ['requests_kerberos>=0.12.0'],
     },
     tests_require=[
@@ -55,7 +55,7 @@ setup(
         'requests>=1.0.0',
         'requests_kerberos>=0.12.0',
         'sasl>=0.2.1',
-        'sqlalchemy>=0.12.0',
+        'sqlalchemy>=0.12.0,<=1.2.8',
         'thrift>=0.10.0',
     ],
     cmdclass={'test': PyTest},


### PR DESCRIPTION
Travis is currently reporting some errors:
1) sqlalchemy 1.3 seems to have introduced a new positional arg called resolve_fks
   for reflect, that causes CI to fail when sqlalchemy installed by pypi is greater
   than 1.2.8. It seems out of scope to migrate PyHive to sqlalchemy 1.3.0, so I just
   added some safeguards in setup.py and travis config to avoid the new version.
2) urllib.util.parse_url seems to refuse to parse http://localhost:99999, raising an
   exception that is not the one expected in the test. Fixed the port with 9999.
3) WAITING_FOR_RESOURCES, QUEUED can be states of a Presto query, add them to the test.

Also tried to bump sqlalchemy to 1.3.0 since it seems a quick and easy win (a lot of projects like Superset need an up to date version of sqlalchemy IIRC). If we like the idea, then this change will force everybody using PyHive to upgrade sqlalchemy as well (not a big deal, seems feasible, but worth to discuss).

Issue #288