### PR TITLE
Add the last query id from presto when doing presto query onto cursor

### DIFF
--- a/pyhive/presto.py
+++ b/pyhive/presto.py
@@ -320,6 +320,8 @@ class Cursor(common.DBAPICursor):
         assert self._state == self._STATE_RUNNING, "Should be running if processing response"
         self._nextUri = response_json.get('nextUri')
         self._columns = response_json.get('columns')
+        if 'id' in response_json:
+            self.last_query_id = response_json['id']
         if 'X-Presto-Clear-Session' in response.headers:
             propname = response.headers['X-Presto-Clear-Session']
             self._session_props.pop(propname, None)
@@ -335,8 +337,6 @@ class Cursor(common.DBAPICursor):
             self._state = self._STATE_FINISHED
         if 'error' in response_json:
             raise DatabaseError(response_json['error'])
-        if 'id' in response_json:
-            self.last_query_id = response_json['id']
 
 
 #

--- a/pyhive/presto.py
+++ b/pyhive/presto.py
@@ -145,6 +145,7 @@ class Cursor(common.DBAPICursor):
         self._poll_interval = poll_interval
         self._source = source
         self._session_props = session_props if session_props is not None else {}
+        self.last_query_id = None
 
         if protocol not in ('http', 'https'):
             raise ValueError("Protocol must be http/https, was {!r}".format(protocol))
@@ -334,6 +335,8 @@ class Cursor(common.DBAPICursor):
             self._state = self._STATE_FINISHED
         if 'error' in response_json:
             raise DatabaseError(response_json['error'])
+        if 'id' in response_json:
+            self.last_query_id = response_json['id']
 
 
 #

--- a/pyhive/tests/test_presto.py
+++ b/pyhive/tests/test_presto.py
@@ -168,6 +168,7 @@ class TestPresto(unittest.TestCase, DBAPITestCase):
         cursor.execute('SHOW SESSION')
         self.assertIsNotNone(cursor.last_query_id)
         self.assertNotEqual(id, cursor.last_query_id)
+        id = cursor.last_query_id
         rows = [r for r in cursor.fetchall() if r[0] == 'query_max_run_time']
         self.assertEqual(len(rows), 1)
         session_prop = rows[0]


### PR DESCRIPTION
This means that you don't have to dig around, and try and figure out what ._nextUri is doing when doing a fetchone() and doing the wait.

A pretty trivial pull request, but allows us to log the query_id explicitly.