### PR TITLE
Overrides supports_sane_rowcount in hive dialect

### DIFF
--- a/pyhive/sqlalchemy_hive.py
+++ b/pyhive/sqlalchemy_hive.py
@@ -246,6 +246,7 @@ class HiveDialect(default.DefaultDialect):
     description_encoding = None
     supports_multivalues_insert = True
     type_compiler = HiveTypeCompiler
+    supports_sane_rowcount = False
 
     @classmethod
     def dbapi(cls):

--- a/pyhive/tests/test_sqlalchemy_hive.py
+++ b/pyhive/tests/test_sqlalchemy_hive.py
@@ -212,3 +212,7 @@ class TestSqlAlchemyHive(unittest.TestCase, SqlAlchemyTestCase):
         result = table.select().execute().fetchall()
         expected = [(1,), (2,)]
         self.assertEqual(result, expected)
+
+    @with_engine_connection
+    def test_supports_san_rowcount(self, engine, connection):
+        self.assertFalse(engine.dialect.supports_sane_rowcount_returning)


### PR DESCRIPTION
Fixes #315 

This change will allow those tools depend on SQLAlchemy to not use `resultret.rowcount` when executing statement like `UPDATE` or `DELETE`.