### PR TITLE
Revert travis changes [ubuntu & python upgrade]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,16 @@ matrix:
   include:
     # https://docs.python.org/devguide/#status-of-python-branches
     # One build pulls latest versions dynamically
-    - python: 3.8
-      env: CDH=cdh5 CDH_VERSION=5 PRESTO=RELEASE
-    - python: 3.7
-      env: CDH=cdh5 CDH_VERSION=5 PRESTO=RELEASE
     - python: 3.6
-      env: CDH=cdh5 CDH_VERSION=5 PRESTO=RELEASE
+      env: CDH=cdh5 CDH_VERSION=5 PRESTO=RELEASE SQLALCHEMY=sqlalchemy>=1.3.0
     - python: 3.6
-      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147
+      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147 SQLALCHEMY=sqlalchemy>=1.3.0
     - python: 3.5
-      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147
+      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147 SQLALCHEMY=sqlalchemy>=1.3.0
     - python: 3.4
-      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147
+      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147 SQLALCHEMY=sqlalchemy>=1.3.0
     - python: 2.7
-      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147
+      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147 SQLALCHEMY=sqlalchemy>=1.3.0
 install:
   - ./scripts/travis-install.sh
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 language: python
-dist: xenial
+dist: trusty
 matrix:
   include:
     # https://docs.python.org/devguide/#status-of-python-branches
@@ -12,17 +12,13 @@ matrix:
     - python: 3.6
       env: CDH=cdh5 CDH_VERSION=5 PRESTO=RELEASE
     - python: 3.6
-      env: CDH=cdh5 CDH_VERSION=5.11 PRESTO=0.147
+      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147
     - python: 3.5
-      env: CDH=cdh5 CDH_VERSION=5.11 PRESTO=0.147
+      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147
     - python: 3.4
-      env: CDH=cdh5 CDH_VERSION=5.11 PRESTO=0.147
+      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147
     - python: 2.7
-      env: CDH=cdh5 CDH_VERSION=5.11 PRESTO=0.147
-  addons:
-    apt:
-      packages:
-        - oracle-java8-installer
+      env: CDH=cdh5 CDH_VERSION=5.10.1 PRESTO=0.147
 install:
   - ./scripts/travis-install.sh
   - pip install codecov

--- a/scripts/travis-install.sh
+++ b/scripts/travis-install.sh
@@ -7,7 +7,8 @@ deb-src https://archive.cloudera.com/${CDH}/ubuntu/${DISTRIB_CODENAME}/amd64/cdh
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 327574EE02A818DD
 sudo apt-get -q update
 
-sudo apt-get -q install -y python-dev g++ libsasl2-dev maven
+sudo apt-get -q install -y oracle-java8-installer python-dev g++ libsasl2-dev maven
+sudo update-java-alternatives -s java-8-oracle
 
 #
 # LDAP

--- a/scripts/travis-install.sh
+++ b/scripts/travis-install.sh
@@ -65,6 +65,8 @@ cp -r $(dirname $0)/travis-conf/presto presto-server/etc
 #
 # Python
 #
+
+pip install $SQLALCHEMY
 pip install -e .
 pip install -r dev_requirements.txt
 


### PR DESCRIPTION
Looks like oracle jdk is not supported in the xenial ubuntu in travis:
https://github.com/travis-ci/travis-ci/issues/10290
https://travis-ci.community/t/oracle-jdk-11-and-10-are-pre-installed-not-the-openjdk-builds/785

And the build fails on the openjdk - upgrading ubuntu would require more investigation.
For now reverting the changes.
cc : @Fokko 