### PR TITLE
Add authentication using Hadoop delegation token

### DIFF
--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -105,8 +105,8 @@ class Connection(object):
         :param host: What host HiveServer2 runs on
         :param port: What port HiveServer2 runs on. Defaults to 10000.
         :param auth: The value of hive.server2.authentication used by HiveServer2.
-            For Kerberos mode auth='KERBEROS' uses the cached Kerberos ticket-granting ticket
-            and auth='DELEGATION-TOKEN' uses username and password from a Hadoop delegation token.
+            For Kerberos mode: auth='KERBEROS' uses the cached Kerberos ticket-granting ticket
+            and auth='DELEGATION-TOKEN' uses username and password from the Hadoop delegation token.
             Defaults to ``NONE``.
         :param configuration: A dictionary of Hive settings (functionally same as the `set` command)
         :param kerberos_service_name: Use with auth='KERBEROS' only

--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -106,7 +106,7 @@ class Connection(object):
         :param port: What port HiveServer2 runs on. Defaults to 10000.
         :param auth: The value of hive.server2.authentication used by HiveServer2.
             For Kerberos mode: auth='KERBEROS' uses the cached Kerberos ticket-granting ticket
-            and auth='DELEGATION-TOKEN' uses username and password from the Hadoop delegation token.
+            and auth='DELEGATION-TOKEN' uses the username and password from the Hadoop delegation token.
             Defaults to ``NONE``.
         :param configuration: A dictionary of Hive settings (functionally same as the `set` command)
         :param kerberos_service_name: Use with auth='KERBEROS' only

--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -159,7 +159,8 @@ class Connection(object):
                     # KERBEROS mode in hive.server2.authentication is GSSAPI in sasl library
                     sasl_auth = 'GSSAPI'
                 elif auth == 'DELEGATION-TOKEN':
-                    # 'auth=delegationToken' in Hive jdbc connection string is DIGEST-MD5 in sasl library
+                    # 'auth=delegationToken' in Hive jdbc connection string is DIGEST-MD5
+                    # in sasl library
                     sasl_auth = 'DIGEST-MD5'
                 else:
                     sasl_auth = 'PLAIN'

--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -105,8 +105,8 @@ class Connection(object):
         :param host: What host HiveServer2 runs on
         :param port: What port HiveServer2 runs on. Defaults to 10000.
         :param auth: The value of hive.server2.authentication used by HiveServer2.
-            For Kerberos mode: auth='KERBEROS' uses the cached Kerberos ticket-granting ticket
-            and auth='DELEGATION-TOKEN' uses the username and password from the Hadoop delegation token.
+            For Kerberos mode: auth='KERBEROS' uses the cached Kerberos ticket-granting ticket and
+            auth='DELEGATION-TOKEN' uses the username and password from the Hadoop delegation token.
             Defaults to ``NONE``.
         :param configuration: A dictionary of Hive settings (functionally same as the `set` command)
         :param kerberos_service_name: Use with auth='KERBEROS' only
@@ -122,7 +122,8 @@ class Connection(object):
         configuration = configuration or {}
 
         if (password is not None) != (auth in ('LDAP', 'CUSTOM', 'DELEGATION-TOKEN')):
-            raise ValueError("Password should be set if and only if in LDAP, CUSTOM or DELEGATION-TOKEN mode; "
+            raise ValueError("Password should be set if and only if in LDAP, CUSTOM or "
+                             "DELEGATION-TOKEN mode; "
                              "Remove password or use one of those modes")
         if (kerberos_service_name is not None) != (auth == 'KERBEROS'):
             raise ValueError("kerberos_service_name should be set if and only if in KERBEROS mode")
@@ -159,7 +160,6 @@ class Connection(object):
                     sasl_auth = 'GSSAPI'
                 elif auth == 'DELEGATION-TOKEN':
                     # 'auth=delegationToken' in Hive jdbc connection string is DIGEST-MD5 in sasl library
-                    # https://github.com/apache/hive/blob/master/beeline/src/test/org/apache/hive/beeline/ProxyAuthTest.java#L137
                     sasl_auth = 'DIGEST-MD5'
                 else:
                     sasl_auth = 'PLAIN'


### PR DESCRIPTION
Hi, first I would like to thank you for implementing this library, it's very useful.

In my company, we have a Hadoop cluster with JupyterHub running on an edge node and Jupyter notebooks running inside Yarn containers. The notebooks are deployed with [skein](https://github.com/jcrist/skein). 
I would like to use PyHive to connect to Hive from Jupyter notebooks running inside Yarn.

The authentication from inside Yarn containers is made with Hadoop Delegation Tokens and I was missing this way of authenticating in your library. That is why I made this pull-request. :)

To connect to a Hive server using delegation token you first need to extract the username and the password from the token file. I made a small java program for it that I intend to add it to the skein library:
https://github.com/georgepachitariu/skein/pull/1/files

The python code with all put together is like this:
```
import os
from pyhive import hive

classpath = 'skein.jar:$HADOOP_COMMON_HOME/lib/*:$HADOOP_COMMON_HOME/*'
program = "java -cp " + classpath + " com.anaconda.skein.UserTools print-hive-user-pass $HADOOP_TOKEN_FILE_LOCATION"
username, password, _ = os.popen(program).read().split('\n')

conn = hive.Connection(host="127.0.0.1", port=10000,
                       username=username, password=password,
                       auth='DELEGATION-TOKEN')
```

This is my first draft. Please tell me what do you think about it.

I filled in the Dropbox Contributor License Agreement.