### PR TITLE
Fix queries with wildcards

### DIFF
--- a/pyhive/presto.py
+++ b/pyhive/presto.py
@@ -253,7 +253,7 @@ class Cursor(common.DBAPICursor):
             )
 
         # Prepare statement
-        if parameters is None:
+        if parameters is None or len(parameters) == 0:
             sql = operation
         else:
             sql = operation % _escaper.escape_args(parameters)


### PR DESCRIPTION
This patch fixes queries that use wildcards (%) in SQLAlchemy. The params argument is an empty dict if no extra parameters are provided. This causes [line 256 of presto.py](https://github.com/esemeniuc/PyHive/blob/6ef94d12f0a53c6c35b60bf335a731e3b585c9e6/pyhive/presto.py#L256) to always branch to the `else` case, which causes an error (see the bottom).

Here is a minimal example to trigger the bug:

```python
from sqlalchemy.engine import create_engine
engine = create_engine('presto://localhost:8080/hive/importdemo4')
engine.execute("CREATE TABLE demo_table (X VARCHAR)")
resultProxy = engine.execute("SELECT * FROM demo_table where x like 'a%'")
print(resultProxy.fetchone())
```

Resulting error:
```
Traceback (most recent call last):
  File "/Users/e.semeniuc/dev/SDB-Health-Report/prestodemo.py", line 31, in <module>
    resultProxy = engine.execute("SELECT * FROM demo_table where x like 'a%'")
  File "/Users/e.semeniuc/dev/SDB-Health-Report/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 2238, in execute
    return connection.execute(statement, *multiparams, **params)
  File "/Users/e.semeniuc/dev/SDB-Health-Report/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1006, in execute
    return self._execute_text(object_, multiparams, params)
  File "/Users/e.semeniuc/dev/SDB-Health-Report/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1175, in _execute_text
    ret = self._execute_context(
  File "/Users/e.semeniuc/dev/SDB-Health-Report/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1317, in _execute_context
    self._handle_dbapi_exception(
  File "/Users/e.semeniuc/dev/SDB-Health-Report/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1515, in _handle_dbapi_exception
    util.raise_(exc_info[1], with_traceback=exc_info[2])
  File "/Users/e.semeniuc/dev/SDB-Health-Report/venv/lib/python3.8/site-packages/sqlalchemy/util/compat.py", line 178, in raise_
    raise exception
  File "/Users/e.semeniuc/dev/SDB-Health-Report/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1277, in _execute_context
    self.dialect.do_execute(
  File "/Users/e.semeniuc/dev/SDB-Health-Report/venv/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 593, in do_execute
    cursor.execute(statement, parameters)
  File "/Users/e.semeniuc/dev/SDB-Health-Report/venv/lib/python3.8/site-packages/pyhive/presto.py", line 249, in execute
    sql = operation % _escaper.escape_args(parameters)
ValueError: unsupported format character ''' (0x27) at index 41
```