### PR TITLE
Make timezone for presto configurable via parameters

### DIFF
--- a/pyhive/presto.py
+++ b/pyhive/presto.py
@@ -91,7 +91,7 @@ class Cursor(common.DBAPICursor):
 
     def __init__(self, host, port='8080', username=None, principal_username=None, catalog='hive',
                  schema='default', poll_interval=1, source='pyhive', session_props=None,
-                 protocol='http', password=None, requests_session=None, requests_kwargs=None,
+                 protocol='http', tz=None, password=None, requests_session=None, requests_kwargs=None,
                  KerberosRemoteServiceName=None, KerberosPrincipal=None,
                  KerberosConfigPath=None, KerberosKeytabPath=None,
                  KerberosCredentialCachePath=None, KerberosUseCanonicalHostname=None):
@@ -108,6 +108,7 @@ class Cursor(common.DBAPICursor):
         :param source: string -- arbitrary identifier (shows up in the Presto monitoring page)
         :param protocol: string -- network protocol, valid options are ``http`` and ``https``.
             defaults to ``http``
+        :param tz: string -- timezone to use for timezone-aware timestamps. Defaults to ``None``.
         :param password: string -- Deprecated. Defaults to ``None``.
             Using BasicAuth, requires ``https``.
             Prefer ``requests_kwargs={'auth': HTTPBasicAuth(username, password)}``.
@@ -151,6 +152,7 @@ class Cursor(common.DBAPICursor):
         self._username = principal_username or username or getpass.getuser()
         self._catalog = catalog
         self._schema = schema
+        self._tz = tz
         self._arraysize = 1
         self._poll_interval = poll_interval
         self._source = source
@@ -244,6 +246,7 @@ class Cursor(common.DBAPICursor):
             'X-Presto-Schema': self._schema,
             'X-Presto-Source': self._source,
             'X-Presto-User': self._username,
+            'X-Presto-Time-Zone': self._tz,
         }
 
         if self._session_props:


### PR DESCRIPTION
Presto offers the option to request timezone aware timestamps for a specific timezone (see [here](https://prestodb.io/docs/current/release/release-0.66.html)). This PR adds support to pass an optional timezone to presto.

Partial solution for #363 .

CLA is signed.