### PR TITLE
Give python2 backward compatibility to trino.py

### DIFF
--- a/pyhive/trino.py
+++ b/pyhive/trino.py
@@ -48,7 +48,7 @@ def connect(*args, **kwargs):
 
 class Connection(PrestoConnection):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(Connection, self).__init__(*args, **kwargs)
 
     def cursor(self):
         """Return a new :py:class:`Cursor` object using the connection."""


### PR DESCRIPTION
I made a small change in trino.py because `super()` syntax is not compatible to python2.