### PR TITLE
Add date parser

### DIFF
--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -68,8 +68,21 @@ def _parse_timestamp(value):
     return value
 
 
+def _parse_date(value):
+    if value:
+        try:
+            value = datetime.date.fromisoformat(value)
+        except:
+            raise Exception(
+                'Cannot convert "{}" into a date'.format(value))
+    else:
+        value = None
+    return value
+
+
 TYPES_CONVERTER = {"DECIMAL_TYPE": Decimal,
-                   "TIMESTAMP_TYPE": _parse_timestamp}
+                   "TIMESTAMP_TYPE": _parse_timestamp,
+                   "DATE_TYPE" : _parse_date}
 
 
 class HiveParamEscaper(common.ParamEscaper):


### PR DESCRIPTION
Add _parse_date function modeled off _parse_timestamp. Hive introduced the DATE_TYPE in 0.12.0, and we're already translate 0.8.0's TIMESTAMP_TYPE to datetime. It seems like a logical enhancement to translate dates into datetime.date objects.