### PR TITLE
Added timeout parameter for Connection class

### DIFF
--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -120,7 +120,8 @@ class Connection(object):
         password=None,
         check_hostname=None,
         ssl_cert=None,
-        thrift_transport=None
+        thrift_transport=None,
+        timeout=None
     ):
         """Connect to HiveServer2
 
@@ -152,6 +153,7 @@ class Connection(object):
                 ),
                 ssl_context=ssl_context,
             )
+            thrift_transport.setTimeout(timeout)
 
             if auth in ("BASIC", "NOSASL", "NONE", None):
                 # Always needs the Authorization header
@@ -195,6 +197,7 @@ class Connection(object):
             if auth is None:
                 auth = 'NONE'
             socket = thrift.transport.TSocket.TSocket(host, port)
+            socket.setTimeout(timeout)
             if auth == 'NOSASL':
                 # NOSASL corresponds to hive.server2.authentication=NOSASL in hive-site.xml
                 self._transport = thrift.transport.TTransport.TBufferedTransport(socket)


### PR DESCRIPTION
**What:**
Pyhive does not support custom connection timeout, and user may have to wait long time-period unwillingly before an exception is raised. 
This PR would add an extra optional parameter `timeout` to `Connection` class which would allow users to set custom timeout for hive connections.

**How:**
This PR exposes the underlying timeout functionality of `TSocket` and `THttpClient` to `Connection` class for the users which add extra flexibility for advanced users, who might need more flexibility, and is also backward compatible
