### PR TITLE
chore: rename Trino entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
             "hive.http = pyhive.sqlalchemy_hive:HiveHTTPDialect",
             "hive.https = pyhive.sqlalchemy_hive:HiveHTTPSDialect",
             'presto = pyhive.sqlalchemy_presto:PrestoDialect',
-            'trino = pyhive.sqlalchemy_trino:TrinoDialect',
+            'trino.pyhive = pyhive.sqlalchemy_trino:TrinoDialect',
         ],
     }
 )


### PR DESCRIPTION
This PR addresses https://github.com/dropbox/PyHive/issues/427.

It renames the `trino://` entry point to `trino+pyhive://` to prevent conflict with `sqlalchemy-trino` when both libraries are installed.