### PR TITLE
remove length from BINARY data type + support VARBINARY data type

### DIFF
--- a/pyhive/sqlalchemy_hive.py
+++ b/pyhive/sqlalchemy_hive.py
@@ -194,6 +194,12 @@ class HiveTypeCompiler(compiler.GenericTypeCompiler):
     def visit_BLOB(self, type_):
         return 'BINARY'
 
+    def visit_BINARY(self, type_):
+        return 'BINARY'
+
+    def visit_VARBINARY(self, type_):
+        return self.visit_BINARY(type_)
+
     def visit_TIME(self, type_):
         return 'TIMESTAMP'
 


### PR DESCRIPTION
The BINARY data type is already supported via [`GenericTypeCompiler`](https://github.com/sqlalchemy/sqlalchemy/blob/1dd0f23e8d74aa7edc8dd309093a95171e2e8f09/lib/sqlalchemy/sql/compiler.py#L6009-L6013) but it has an optional length parameter which is not supported in Hive (see [Hive docs](https://cwiki.apache.org/confluence/display/hive/languagemanual+types)).

With this PR the length parameter for the BINARY type is removed and the VARBINARY type is mapped to `BINARY`.