### PR TITLE
Added SSL support to binary transport

### DIFF
--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -211,6 +211,7 @@ class Connection(object):
                 
             if 'EXTRA_USE_SSL' in configuration.keys():
                 socket = thrift.transport.TSSLSocket.TSSLSocket(host, port, cert_reqs=CERT_NONE)
+                configuration.pop("EXTRA_USE_SSL")
             else:    
                 socket = thrift.transport.TSocket.TSocket(host, port)
                 


### PR DESCRIPTION
This is a PR for handle TLS connection with hive server.
Currently in all release we are not able to establish connection with hive over TLS.

This feature consist in add parameters (EXTRA args) in configuration dictionary and switch library if "USE_SSL".