### PR TITLE
Use str type for driver and name in HiveDialect

### DIFF
--- a/pyhive/sqlalchemy_hive.py
+++ b/pyhive/sqlalchemy_hive.py
@@ -228,8 +228,8 @@ class HiveExecutionContext(default.DefaultExecutionContext):
 
 
 class HiveDialect(default.DefaultDialect):
-    name = b'hive'
-    driver = b'thrift'
+    name = 'hive'
+    driver = 'thrift'
     execution_ctx_cls = HiveExecutionContext
     preparer = HiveIdentifierPreparer
     statement_compiler = HiveCompiler


### PR DESCRIPTION
PyHive's HiveDialect usage of bytes for the name and driver fields is not the norm is causing issues upstream: https://github.com/apache/superset/issues/22316 
Other dialects within PyHive already use strings. While SQLAlchemy does not strictly require a string, all the stock dialects return a string, so I figure it is heavily implied.

I think the risk of breaking something upstream with this change is low (but it is there ofc). I figure in most cases we just make someone's `str(dialect.driver)` expression redundant. To be extra safe we could just go for a major version bump.

Examples for some of the other stock sqlalchemy dialects (name and driver fields using str): https://github.com/zzzeek/sqlalchemy/blob/main/lib/sqlalchemy/dialects/sqlite/pysqlite.py#L501 https://github.com/zzzeek/sqlalchemy/blob/main/lib/sqlalchemy/dialects/sqlite/base.py#L1891 https://github.com/zzzeek/sqlalchemy/blob/main/lib/sqlalchemy/dialects/mysql/base.py#L2383 https://github.com/zzzeek/sqlalchemy/blob/main/lib/sqlalchemy/dialects/mysql/mysqldb.py#L113 https://github.com/zzzeek/sqlalchemy/blob/main/lib/sqlalchemy/dialects/mysql/pymysql.py#L59

PS: I have submitted the CLA.