### PR TITLE
Revert "changing drivers to support hive, presto and trino with sqlalchemy>=2.0"

### DIFF
--- a/pyhive/sqlalchemy_hive.py
+++ b/pyhive/sqlalchemy_hive.py
@@ -13,19 +13,11 @@ import decimal
 
 import re
 from sqlalchemy import exc
-try:
-    from sqlalchemy import processors
-except ImportError:
-    # Newer versions of sqlalchemy require:
-    from sqlalchemy.engine import processors
+from sqlalchemy import processors
 from sqlalchemy import types
 from sqlalchemy import util
 # TODO shouldn't use mysql type
-try:
-    from sqlalchemy.databases.mysql import MSTinyInteger
-except ImportError:
-    # Newer versions of sqlalchemy require:
-    from sqlalchemy.dialects.mysql import MSTinyInteger
+from sqlalchemy.databases import mysql
 from sqlalchemy.engine import default
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql.compiler import SQLCompiler
@@ -129,7 +121,7 @@ class HiveIdentifierPreparer(compiler.IdentifierPreparer):
 
 _type_map = {
     'boolean': types.Boolean,
-    'tinyint': MSTinyInteger,
+    'tinyint': mysql.MSTinyInteger,
     'smallint': types.SmallInteger,
     'int': types.Integer,
     'bigint': types.BigInteger,

--- a/pyhive/sqlalchemy_presto.py
+++ b/pyhive/sqlalchemy_presto.py
@@ -13,11 +13,7 @@ from sqlalchemy import exc
 from sqlalchemy import types
 from sqlalchemy import util
 # TODO shouldn't use mysql type
-try:
-    from sqlalchemy.databases.mysql import MSTinyInteger
-except ImportError:
-    # Newer versions of sqlalchemy require:
-    from sqlalchemy.dialects.mysql import MSTinyInteger
+from sqlalchemy.databases import mysql
 from sqlalchemy.engine import default
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql.compiler import SQLCompiler
@@ -33,7 +29,7 @@ class PrestoIdentifierPreparer(compiler.IdentifierPreparer):
 
 _type_map = {
     'boolean': types.Boolean,
-    'tinyint': MSTinyInteger,
+    'tinyint': mysql.MSTinyInteger,
     'smallint': types.SmallInteger,
     'integer': types.Integer,
     'bigint': types.BigInteger,

--- a/pyhive/sqlalchemy_trino.py
+++ b/pyhive/sqlalchemy_trino.py
@@ -13,11 +13,7 @@ from sqlalchemy import exc
 from sqlalchemy import types
 from sqlalchemy import util
 # TODO shouldn't use mysql type
-try:
-    from sqlalchemy.databases.mysql import MSTinyInteger
-except ImportError:
-    # Newer versions of sqlalchemy require:
-    from sqlalchemy.dialects.mysql import MSTinyInteger
+from sqlalchemy.databases import mysql
 from sqlalchemy.engine import default
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql.compiler import SQLCompiler
@@ -32,7 +28,7 @@ class TrinoIdentifierPreparer(PrestoIdentifierPreparer):
 
 _type_map = {
     'boolean': types.Boolean,
-    'tinyint': MSTinyInteger,
+    'tinyint': mysql.MSTinyInteger,
     'smallint': types.SmallInteger,
     'integer': types.Integer,
     'bigint': types.BigInteger,


### PR DESCRIPTION
```
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[2], line 1
----> 1 from sqlalchemy.databases.mysql import MSTinyInteger

ModuleNotFoundError: No module named 'sqlalchemy.databases.mysql'

In [3]: from sqlalchemy.databases import mysql

In [4]: mysql.MSTinyInteger
Out[4]: sqlalchemy.dialects.mysql.types.TINYINT
```

We need to import `mysql.MSTinyInteger`, not `MSTinyInteger`  directly
