### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/pyhive/__init__.py
+++ b/pyhive/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-__version__ = '0.6.3'
+__version__ = '0.7.0'


### PR DESCRIPTION
Correcting Iterable import for python 3.10 (https://github.com/dropbox/PyHive/pull/451)
Use str type for driver and name in HiveDialect (https://github.com/dropbox/PyHive/pull/450)