### PR TITLE
Adding compatibility with SQLAlchemy 2.0

### DIFF
--- a/pyhive/sqlalchemy_trino.py
+++ b/pyhive/sqlalchemy_trino.py
@@ -13,7 +13,13 @@ from sqlalchemy import exc
 from sqlalchemy import types
 from sqlalchemy import util
 # TODO shouldn't use mysql type
-from sqlalchemy.databases import mysql
+try:
+    from sqlalchemy.databases import mysql
+    mysql_tinyinteger = mysql.MSTinyInteger
+except ImportError:
+    # Required for SQLAlchemy>=2.0
+    from sqlalchemy.dialects import mysql
+    mysql_tinyinteger = mysql.base.MSTinyInteger
 from sqlalchemy.engine import default
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql.compiler import SQLCompiler
@@ -28,7 +34,7 @@ class TrinoIdentifierPreparer(PrestoIdentifierPreparer):
 
 _type_map = {
     'boolean': types.Boolean,
-    'tinyint': mysql.MSTinyInteger,
+    'tinyint': mysql_tinyinteger,
     'smallint': types.SmallInteger,
     'integer': types.Integer,
     'bigint': types.BigInteger,
@@ -67,7 +73,12 @@ class TrinoTypeCompiler(PrestoCompiler):
 
 class TrinoDialect(PrestoDialect):
     name = 'trino'
+    supports_statement_cache = False
 
     @classmethod
     def dbapi(cls):
         return trino
+    
+    @classmethod
+    def import_dbapi(cls):
+        return trino    

--- a/pyhive/tests/sqlalchemy_test_case.py
+++ b/pyhive/tests/sqlalchemy_test_case.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import abc
+import re
 import contextlib
 import functools
 
@@ -14,8 +15,10 @@ from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy.schema import Index
 from sqlalchemy.schema import MetaData
 from sqlalchemy.schema import Table
-from sqlalchemy.sql import expression
+from sqlalchemy.sql import expression, text
+from sqlalchemy import String
 
+sqlalchemy_version = float(re.search(r"^([\d]+\.[\d]+)\..+", sqlalchemy.__version__).group(1))
 
 def with_engine_connection(fn):
     """Pass a connection to the given function and handle cleanup.
@@ -32,19 +35,33 @@ def with_engine_connection(fn):
             engine.dispose()
     return wrapped_fn
 
+def reflect_table(engine, connection, table, include_columns, exclude_columns, resolve_fks):
+    if sqlalchemy_version >= 1.4:
+        insp = sqlalchemy.inspect(engine)
+        insp.reflect_table(
+            table,
+            include_columns=include_columns,
+            exclude_columns=exclude_columns,
+            resolve_fks=resolve_fks,
+        )
+    else:
+        engine.dialect.reflecttable(
+            connection, table, include_columns=include_columns,
+            exclude_columns=exclude_columns, resolve_fks=resolve_fks)
+
 
 class SqlAlchemyTestCase(with_metaclass(abc.ABCMeta, object)):
     @with_engine_connection
     def test_basic_query(self, engine, connection):
-        rows = connection.execute('SELECT * FROM one_row').fetchall()
+        rows = connection.execute(text('SELECT * FROM one_row')).fetchall()
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0].number_of_rows, 1)  # number_of_rows is the column name
         self.assertEqual(len(rows[0]), 1)
 
     @with_engine_connection
     def test_one_row_complex_null(self, engine, connection):
-        one_row_complex_null = Table('one_row_complex_null', MetaData(bind=engine), autoload=True)
-        rows = one_row_complex_null.select().execute().fetchall()
+        one_row_complex_null = Table('one_row_complex_null', MetaData(), autoload_with=engine)
+        rows = connection.execute(one_row_complex_null.select()).fetchall()
         self.assertEqual(len(rows), 1)
         self.assertEqual(list(rows[0]), [None] * len(rows[0]))
 
@@ -53,27 +70,26 @@ class SqlAlchemyTestCase(with_metaclass(abc.ABCMeta, object)):
         """reflecttable should throw an exception on an invalid table"""
         self.assertRaises(
             NoSuchTableError,
-            lambda: Table('this_does_not_exist', MetaData(bind=engine), autoload=True))
+            lambda: Table('this_does_not_exist', MetaData(), autoload_with=engine))
         self.assertRaises(
             NoSuchTableError,
-            lambda: Table('this_does_not_exist', MetaData(bind=engine),
-                          schema='also_does_not_exist', autoload=True))
+            lambda: Table('this_does_not_exist', MetaData(schema='also_does_not_exist'), autoload_with=engine))
 
     @with_engine_connection
     def test_reflect_include_columns(self, engine, connection):
         """When passed include_columns, reflecttable should filter out other columns"""
-        one_row_complex = Table('one_row_complex', MetaData(bind=engine))
-        engine.dialect.reflecttable(
-            connection, one_row_complex, include_columns=['int'],
+
+        one_row_complex = Table('one_row_complex', MetaData())
+        reflect_table(engine, connection, one_row_complex, include_columns=['int'],
             exclude_columns=[], resolve_fks=True)
+
         self.assertEqual(len(one_row_complex.c), 1)
         self.assertIsNotNone(one_row_complex.c.int)
         self.assertRaises(AttributeError, lambda: one_row_complex.c.tinyint)
 
     @with_engine_connection
     def test_reflect_with_schema(self, engine, connection):
-        dummy = Table('dummy_table', MetaData(bind=engine), schema='pyhive_test_database',
-                      autoload=True)
+        dummy = Table('dummy_table', MetaData(schema='pyhive_test_database'), autoload_with=engine)
         self.assertEqual(len(dummy.c), 1)
         self.assertIsNotNone(dummy.c.a)
 
@@ -81,22 +97,22 @@ class SqlAlchemyTestCase(with_metaclass(abc.ABCMeta, object)):
     @with_engine_connection
     def test_reflect_partitions(self, engine, connection):
         """reflecttable should get the partition column as an index"""
-        many_rows = Table('many_rows', MetaData(bind=engine), autoload=True)
+        many_rows = Table('many_rows', MetaData(), autoload_with=engine)
         self.assertEqual(len(many_rows.c), 2)
         self.assertEqual(repr(many_rows.indexes), repr({Index('partition', many_rows.c.b)}))
 
-        many_rows = Table('many_rows', MetaData(bind=engine))
-        engine.dialect.reflecttable(
-            connection, many_rows, include_columns=['a'],
+        many_rows = Table('many_rows', MetaData())
+        reflect_table(engine, connection, many_rows, include_columns=['a'],
             exclude_columns=[], resolve_fks=True)
+        
         self.assertEqual(len(many_rows.c), 1)
         self.assertFalse(many_rows.c.a.index)
         self.assertFalse(many_rows.indexes)
 
-        many_rows = Table('many_rows', MetaData(bind=engine))
-        engine.dialect.reflecttable(
-            connection, many_rows, include_columns=['b'],
+        many_rows = Table('many_rows', MetaData())
+        reflect_table(engine, connection, many_rows, include_columns=['b'],
             exclude_columns=[], resolve_fks=True)
+
         self.assertEqual(len(many_rows.c), 1)
         self.assertEqual(repr(many_rows.indexes), repr({Index('partition', many_rows.c.b)}))
 
@@ -104,11 +120,15 @@ class SqlAlchemyTestCase(with_metaclass(abc.ABCMeta, object)):
     def test_unicode(self, engine, connection):
         """Verify that unicode strings make it through SQLAlchemy and the backend"""
         unicode_str = "中文"
-        one_row = Table('one_row', MetaData(bind=engine))
-        returned_str = sqlalchemy.select(
-            [expression.bindparam("好", unicode_str)],
-            from_obj=one_row,
-        ).scalar()
+        one_row = Table('one_row', MetaData())
+
+        if sqlalchemy_version >= 1.4:
+            returned_str = connection.execute(sqlalchemy.select(
+                expression.bindparam("好", unicode_str, type_=String())).select_from(one_row)).scalar()
+        else:
+            returned_str = connection.execute(sqlalchemy.select([
+                expression.bindparam("好", unicode_str, type_=String())]).select_from(one_row)).scalar()
+        
         self.assertEqual(returned_str, unicode_str)
 
     @with_engine_connection
@@ -133,13 +153,21 @@ class SqlAlchemyTestCase(with_metaclass(abc.ABCMeta, object)):
 
     @with_engine_connection
     def test_has_table(self, engine, connection):
-        self.assertTrue(Table('one_row', MetaData(bind=engine)).exists())
-        self.assertFalse(Table('this_table_does_not_exist', MetaData(bind=engine)).exists())
+        if sqlalchemy_version >= 1.4:
+            insp = sqlalchemy.inspect(engine)
+            self.assertTrue(insp.has_table("one_row"))
+            self.assertFalse(insp.has_table("this_table_does_not_exist"))
+        else:
+            self.assertTrue(Table('one_row', MetaData(bind=engine)).exists())
+            self.assertFalse(Table('this_table_does_not_exist', MetaData(bind=engine)).exists())
 
     @with_engine_connection
     def test_char_length(self, engine, connection):
-        one_row_complex = Table('one_row_complex', MetaData(bind=engine), autoload=True)
-        result = sqlalchemy.select([
-            sqlalchemy.func.char_length(one_row_complex.c.string)
-        ]).execute().scalar()
+        one_row_complex = Table('one_row_complex', MetaData(), autoload_with=engine)
+
+        if sqlalchemy_version >= 1.4:
+            result = connection.execute(sqlalchemy.select(sqlalchemy.func.char_length(one_row_complex.c.string))).scalar()
+        else:
+            result = connection.execute(sqlalchemy.select([sqlalchemy.func.char_length(one_row_complex.c.string)])).scalar()
+
         self.assertEqual(result, len('a string'))

--- a/pyhive/tests/test_sqlalchemy_hive.py
+++ b/pyhive/tests/test_sqlalchemy_hive.py
@@ -4,6 +4,7 @@ from builtins import str
 from pyhive.sqlalchemy_hive import HiveDate
 from pyhive.sqlalchemy_hive import HiveDecimal
 from pyhive.sqlalchemy_hive import HiveTimestamp
+from sqlalchemy.exc import NoSuchTableError, OperationalError
 from pyhive.tests.sqlalchemy_test_case import SqlAlchemyTestCase
 from pyhive.tests.sqlalchemy_test_case import with_engine_connection
 from sqlalchemy import types
@@ -11,11 +12,15 @@ from sqlalchemy.engine import create_engine
 from sqlalchemy.schema import Column
 from sqlalchemy.schema import MetaData
 from sqlalchemy.schema import Table
+from sqlalchemy.sql import text
 import contextlib
 import datetime
 import decimal
 import sqlalchemy.types
 import unittest
+import re
+
+sqlalchemy_version = float(re.search(r"^([\d]+\.[\d]+)\..+", sqlalchemy.__version__).group(1))
 
 _ONE_ROW_COMPLEX_CONTENTS = [
     True,
@@ -64,7 +69,11 @@ class TestSqlAlchemyHive(unittest.TestCase, SqlAlchemyTestCase):
         """When Hive returns a dotted column name, both the non-dotted version should be available
         as an attribute, and the dotted version should remain available as a key.
         """
-        row = connection.execute('SELECT * FROM one_row').fetchone()
+        row = connection.execute(text('SELECT * FROM one_row')).fetchone()
+
+        if sqlalchemy_version >= 1.4:
+            row = row._mapping
+
         assert row.keys() == ['number_of_rows']
         assert 'number_of_rows' in row
         assert row.number_of_rows == 1
@@ -76,20 +85,33 @@ class TestSqlAlchemyHive(unittest.TestCase, SqlAlchemyTestCase):
     def test_dotted_column_names_raw(self, engine, connection):
         """When Hive returns a dotted column name, and raw mode is on, nothing should be modified.
         """
-        row = connection.execution_options(hive_raw_colnames=True) \
-            .execute('SELECT * FROM one_row').fetchone()
+        row = connection.execution_options(hive_raw_colnames=True).execute(text('SELECT * FROM one_row')).fetchone()
+        
+        if sqlalchemy_version >= 1.4:
+            row = row._mapping
+
         assert row.keys() == ['one_row.number_of_rows']
         assert 'number_of_rows' not in row
         assert getattr(row, 'one_row.number_of_rows') == 1
         assert row['one_row.number_of_rows'] == 1
 
     @with_engine_connection
+    def test_reflect_no_such_table(self, engine, connection):
+        """reflecttable should throw an exception on an invalid table"""
+        self.assertRaises(
+            NoSuchTableError,
+            lambda: Table('this_does_not_exist', MetaData(), autoload_with=engine))
+        self.assertRaises(
+            OperationalError,
+            lambda: Table('this_does_not_exist', MetaData(schema="also_does_not_exist"), autoload_with=engine))
+
+    @with_engine_connection
     def test_reflect_select(self, engine, connection):
         """reflecttable should be able to fill in a table from the name"""
-        one_row_complex = Table('one_row_complex', MetaData(bind=engine), autoload=True)
+        one_row_complex = Table('one_row_complex', MetaData(), autoload_with=engine)
         self.assertEqual(len(one_row_complex.c), 15)
         self.assertIsInstance(one_row_complex.c.string, Column)
-        row = one_row_complex.select().execute().fetchone()
+        row = connection.execute(one_row_complex.select()).fetchone()
         self.assertEqual(list(row), _ONE_ROW_COMPLEX_CONTENTS)
 
         # TODO some of these types could be filled in better
@@ -112,15 +134,15 @@ class TestSqlAlchemyHive(unittest.TestCase, SqlAlchemyTestCase):
     @with_engine_connection
     def test_type_map(self, engine, connection):
         """sqlalchemy should use the dbapi_type_map to infer types from raw queries"""
-        row = connection.execute('SELECT * FROM one_row_complex').fetchone()
+        row = connection.execute(text('SELECT * FROM one_row_complex')).fetchone()
         self.assertListEqual(list(row), _ONE_ROW_COMPLEX_CONTENTS)
 
     @with_engine_connection
     def test_reserved_words(self, engine, connection):
         """Hive uses backticks"""
         # Use keywords for the table/column name
-        fake_table = Table('select', MetaData(bind=engine), Column('map', sqlalchemy.types.String))
-        query = str(fake_table.select(fake_table.c.map == 'a'))
+        fake_table = Table('select', MetaData(), Column('map', sqlalchemy.types.String))
+        query = str(fake_table.select().where(fake_table.c.map == 'a').compile(engine))
         self.assertIn('`select`', query)
         self.assertIn('`map`', query)
         self.assertNotIn('"select"', query)
@@ -132,12 +154,12 @@ class TestSqlAlchemyHive(unittest.TestCase, SqlAlchemyTestCase):
             with contextlib.closing(engine.connect()) as connection:
                 self.assertIn(
                     ('dummy_table',),
-                    connection.execute('SHOW TABLES').fetchall()
+                    connection.execute(text('SHOW TABLES')).fetchall()
                 )
-                connection.execute('USE default')
+                connection.execute(text('USE default'))
                 self.assertIn(
                     ('one_row',),
-                    connection.execute('SHOW TABLES').fetchall()
+                    connection.execute(text('SHOW TABLES')).fetchall()
                 )
         finally:
             engine.dispose()
@@ -160,13 +182,13 @@ class TestSqlAlchemyHive(unittest.TestCase, SqlAlchemyTestCase):
         cols.append(Column('hive_date', HiveDate))
         cols.append(Column('hive_decimal', HiveDecimal))
         cols.append(Column('hive_timestamp', HiveTimestamp))
-        table = Table('test_table', MetaData(bind=engine), *cols, schema='pyhive_test_database')
-        table.drop(checkfirst=True)
-        table.create()
-        connection.execute('SET mapred.job.tracker=local')
-        connection.execute('USE pyhive_test_database')
+        table = Table('test_table', MetaData(schema='pyhive_test_database'), *cols,)
+        table.drop(checkfirst=True, bind=connection)
+        table.create(bind=connection)
+        connection.execute(text('SET mapred.job.tracker=local'))
+        connection.execute(text('USE pyhive_test_database'))
         big_number = 10 ** 10 - 1
-        connection.execute("""
+        connection.execute(text("""
         INSERT OVERWRITE TABLE test_table
         SELECT
             1, "a", "a", "a", "a", "a", 0.1,
@@ -175,41 +197,39 @@ class TestSqlAlchemyHive(unittest.TestCase, SqlAlchemyTestCase):
             "a", 1, 1,
             0.1, 0.1, 0, 0, 0, "a",
             false, "a", "a",
-            0, %d, 123 + 2000
+            0, :big_number, 123 + 2000
         FROM default.one_row
-        """, big_number)
-        row = connection.execute(table.select()).fetchone()
-        self.assertEqual(row.hive_date, datetime.date(1970, 1, 1))
+        """), {"big_number": big_number})
+        row = connection.execute(text("select * from test_table")).fetchone()
+        self.assertEqual(row.hive_date, datetime.datetime(1970, 1, 1, 0, 0))
         self.assertEqual(row.hive_decimal, decimal.Decimal(big_number))
         self.assertEqual(row.hive_timestamp, datetime.datetime(1970, 1, 1, 0, 0, 2, 123000))
-        table.drop()
+        table.drop(bind=connection)
 
     @with_engine_connection
     def test_insert_select(self, engine, connection):
-        one_row = Table('one_row', MetaData(bind=engine), autoload=True)
-        table = Table('insert_test', MetaData(bind=engine),
-                      Column('a', sqlalchemy.types.Integer),
-                      schema='pyhive_test_database')
-        table.drop(checkfirst=True)
-        table.create()
-        connection.execute('SET mapred.job.tracker=local')
+        one_row = Table('one_row', MetaData(), autoload_with=engine)
+        table = Table('insert_test', MetaData(schema='pyhive_test_database'),
+                      Column('a', sqlalchemy.types.Integer))
+        table.drop(checkfirst=True, bind=connection)
+        table.create(bind=connection)
+        connection.execute(text('SET mapred.job.tracker=local'))
         # NOTE(jing) I'm stuck on a version of Hive without INSERT ... VALUES
         connection.execute(table.insert().from_select(['a'], one_row.select()))
-
-        result = table.select().execute().fetchall()
+        
+        result = connection.execute(table.select()).fetchall()
         expected = [(1,)]
         self.assertEqual(result, expected)
 
     @with_engine_connection
     def test_insert_values(self, engine, connection):
-        table = Table('insert_test', MetaData(bind=engine),
-                      Column('a', sqlalchemy.types.Integer),
-                      schema='pyhive_test_database')
-        table.drop(checkfirst=True)
-        table.create()
-        connection.execute(table.insert([{'a': 1}, {'a': 2}]))
+        table = Table('insert_test', MetaData(schema='pyhive_test_database'),
+                      Column('a', sqlalchemy.types.Integer),)
+        table.drop(checkfirst=True, bind=connection)
+        table.create(bind=connection)
+        connection.execute(table.insert().values([{'a': 1}, {'a': 2}]))
 
-        result = table.select().execute().fetchall()
+        result = connection.execute(table.select()).fetchall()
         expected = [(1,), (2,)]
         self.assertEqual(result, expected)
 


### PR DESCRIPTION
**Description**

This PR includes minimal changes to add SQLAlchemy 2.0 support without breaking compatibility with SQLAlchemy 1.3 and SQLAlchemy 1.4. 

**Test Environment**

SQLALchemy 1.3.24, 1.4.36, and 2.0.16 was used with [this hive docker setup](https://github.com/big-data-europe/docker-hive/blob/master/docker-compose.yml) for running the test cases. Trino isn't present in that setup, so I added the below lines to docker-compose.yaml and copied [trino config from pyhive repository](https://github.com/dropbox/PyHive/tree/master/scripts/travis-conf/trino) to the Trino container as a volume. That's it, My testing setup was ready. 

  trino:    
    image: trinodb/trino:351    
    ports:     
      - "18080:18080"    
    volumes:    
      - ./trino:/etc/trino    

**Software versions used in test setup**

Hive version - 2.3.2
Presto version - 0.181
Trino version - 351

**Local test case run results:** 

1) SQLAlchemy 1.3 + Hive

![1 3-hive](https://github.com/dropbox/PyHive/assets/57723564/6e157fd9-b7c0-4826-bcdb-b359de2640a1)

2) SQLAlchemy 1.3 + Presto

![1 3-presto](https://github.com/dropbox/PyHive/assets/57723564/0c18686f-d740-4432-b19e-ad74ea241ded)

3) SQLAlchemy 1.3 + Trino

![image](https://github.com/dropbox/PyHive/assets/57723564/c6ebb1fa-be69-4a23-8708-1613479f55cd)

4) SQLAlchemy 1.4 + Hive

![1 4-hive](https://github.com/dropbox/PyHive/assets/57723564/f628c2f0-8d5d-473d-8f5b-be72173a8cb4)

5) SQLAlchemy 1.4 + Presto

![1 4-presto](https://github.com/dropbox/PyHive/assets/57723564/ba93c63f-ed52-4060-b6ba-a8ff5c638281)

6) SQLAlchemy 1.4 + Trino

![image](https://github.com/dropbox/PyHive/assets/57723564/c4b4ed2b-a539-4ab8-afc8-9d2e5fb1c6d6)

7) SQLAlchemy 2.0 + Hive

![2 0-hive](https://github.com/dropbox/PyHive/assets/57723564/bd4d45ef-3f5c-4774-b84b-51f4a79a8ce0)

8) SQLAlchemy 2.0 + Presto

![2 0-presto](https://github.com/dropbox/PyHive/assets/57723564/ba138517-01b2-4ce2-8cd4-6528258a7b81)

9) SQLAlchemy 2.0 + Trino

![image](https://github.com/dropbox/PyHive/assets/57723564/63ce2a9b-d561-41d2-89d0-cc2e320bceff)




