### PR TITLE
Add is_open to check transport of connection

### DIFF
--- a/pyhive/hive.py
+++ b/pyhive/hive.py
@@ -354,6 +354,9 @@ class Connection(object):
     def sessionHandle(self):
         return self._sessionHandle
 
+    def is_open(self):
+        return self._transport.isOpen()
+
     def rollback(self):
         raise NotSupportedError("Hive does not have transactions")  # pragma: no cover
 


### PR DESCRIPTION
To check whether the transport of connection is open or not, It would be great is_open method exists.
Checking the connection first is helpful to prevent BrokenPIpeError from occuring and gives a chance to build a new connection.

AS-IS:
```python
connection = hive.connect(host=_HOST)
print(connection._transport.isOpen())
```

TO-BE:
```python
connection = hive.connect(host=_HOST)
print(connection.is_open())
```