### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'presto': ['requests>=1.0.0'],
         'trino': ['requests>=1.0.0'],
         'hive': ['sasl>=0.2.1', 'thrift>=0.10.0', 'thrift_sasl>=0.1.0'],
-        'hive_pure_sasl': ['pure-sasl>=0.6.2', 'thrift>=0.10.0', 'thrift_sasl>=0.1.0'],
+        'hive_pure_sasl': ['pure-sasl[GSSAPI]>=0.6.2', 'thrift>=0.10.0', 'thrift_sasl>=0.1.0'],
         'sqlalchemy': ['sqlalchemy>=1.3.0'],
         'kerberos': ['requests_kerberos>=0.12.0'],
     },


### PR DESCRIPTION
Currently, PyHive relies on pure-sasl for SASL authentication. However, when attempting to use Kerberos (GSSAPI) authentication, the connection fails with an error such as:
Could not start SASL: None of the mechanisms listed meet all required properties
This happens because pure-sasl does not include GSSAPI support by default. To enable Kerberos, the package must be installed with the GSSAPI extra:
pure-sasl[GSSAPI]
This change ensures that PyHive declares the correct dependency so Kerberos authentication works out of the box. Without this, Kerberos connections will always fail unless users manually install the missing requirement.